### PR TITLE
fix(frontend): fix event detail page race condition and infinite re-render

### DIFF
--- a/frontend/src/app/event/[id]/page.tsx
+++ b/frontend/src/app/event/[id]/page.tsx
@@ -794,7 +794,7 @@ function FullView({
 
 export default function EventDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, isInitialized } = useAuth();
 
   const [event, setEvent] = useState<AnyEventDetail | null>(null);
   const [host, setHost] = useState<HostProfile | null>(null);
@@ -802,7 +802,12 @@ export default function EventDetailPage() {
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
-    if (!id) return;
+    // Wait for session to initialize so the token is available before fetching.
+    // Without this, the request races with refreshSession and may send no token,
+    // causing the backend to return a limited/guest response even for logged-in users.
+    if (!id || !isInitialized) return;
+    setLoading(true);
+    setNotFound(false);
     fetchEventDetail(id)
       .then((ev) => {
         setEvent(ev);
@@ -814,7 +819,7 @@ export default function EventDetailPage() {
       })
       .catch(() => setNotFound(true))
       .finally(() => setLoading(false));
-  }, [id]);
+  }, [id, isInitialized]);
 
   const isHost =
     event?._type === "full" && !!user && !!event.host_id && event.host_id === user.id;

--- a/frontend/src/hooks/use-event-interaction.ts
+++ b/frontend/src/hooks/use-event-interaction.ts
@@ -39,15 +39,20 @@ export function useEventInteraction({
     going: initialGoing,
     goingCount: Math.max(initialGoingCount, initialGoing ? 1 : 0),
   };
-  // Detail page passes fresh=true to overwrite stale card data with server truth
-  if (fresh) {
-    refreshInteraction(eventId, data);
-  } else {
-    initInteraction(eventId, data);
-  }
+  // Always init during render (safe — initInteraction never calls notify)
+  initInteraction(eventId, data);
 
   const [, tick] = useState(0);
   useEffect(() => subscribe(() => tick((n) => n + 1)), []);
+
+  // refreshInteraction calls notify() which triggers state updates — must be in useEffect
+  useEffect(() => {
+    if (fresh) {
+      refreshInteraction(eventId, data);
+    }
+    // data is intentionally excluded from deps: we only want to refresh on eventId change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventId, fresh]);
 
   const state = getInteraction(eventId)!;
 


### PR DESCRIPTION
Wait for session initialization before fetching event detail so the
access token is available, preventing logged-in users from seeing the
guest/limited view on page refresh.

Move refreshInteraction() call into useEffect in useEventInteraction
hook to prevent infinite re-render loop caused by calling notify()
during render when fresh=true.

Closes #174 