### PR TITLE
fix: add missing Suspense boundary to /profile/me to fix Next.js build bailout

### DIFF
--- a/frontend/src/app/profile/me/page.tsx
+++ b/frontend/src/app/profile/me/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import { MyProfilePage } from "@/components/profile/my-profile-page";
 
 export default function ProfileMePage() {
-  return <MyProfilePage />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MyProfilePage />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
### Fix: Resolve Next.js CSR Bailout on `/profile/me` Route

**Issue:** The build pipeline was failing (`missing-suspense-with-csr-bailout`) because `useSearchParams()` was being used in the `MyProfilePage` component without a Suspense boundary, causing Next.js to de-opt the entire route from static rendering during the build step.

**Fix:** Wrapped the `<MyProfilePage />` component inside a React `<Suspense>` boundary in `frontend/src/app/profile/me/page.tsx`. This tells Next.js to render the rest of the page statically and load the search params part dynamically, successfully resolving the deployment crash.
