### PR TITLE
fix: redirect to event detail page after publish

### DIFF
--- a/frontend/src/components/events/event-editor.tsx
+++ b/frontend/src/components/events/event-editor.tsx
@@ -923,7 +923,7 @@ export function EventEditor({ eventId, mode }: EventEditorProps) {
       setFeedback({ message: "Event published successfully.", tone: "success" });
 
       if (mode === "create") {
-        router.replace(getEditEventPagePath(publishedEvent.id));
+        router.replace(`/event/${publishedEvent.id}`);
       }
     } catch (error) {
       setFeedback({


### PR DESCRIPTION
## Summary

After publishing an event, users were being redirected to the edit page instead of the event detail page.

## Fix

Changed post-publish redirect in `event-editor.tsx` from `getEditEventPagePath` to `/event/{id}`.

## Test Plan

- Create and publish an event
- Verify redirect lands on `/event/{id}` (public detail view)
- Verify the published event is visible as attendees would see it

Closes #197