### PR TITLE
fix(frontend): multiple UI and UX fixes for MVP milestone

### DIFF
--- a/frontend/src/app/event/[id]/page.tsx
+++ b/frontend/src/app/event/[id]/page.tsx
@@ -394,7 +394,7 @@ function LimitedView({
               <button
                 onClick={() => { void handleRequestAccess(); }}
                 disabled={accessStatus === "loading"}
-                className="w-full flex items-center justify-center gap-2 rounded-lg bg-brand-dark px-5 py-3 text-sm font-bold text-white transition-all hover:bg-brand-dark/85 hover:-translate-y-0.5 hover:shadow-lg disabled:opacity-60 disabled:cursor-not-allowed"
+                className="w-full flex items-center justify-center gap-2 rounded-lg bg-brand-dark px-5 py-3 text-sm font-bold text-white transition-all hover:bg-brand-dark/85 hover:-translate-y-0.5 hover:shadow-lg cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {accessStatus === "loading" ? (
                   <Loader2 className="size-4 animate-spin" />
@@ -637,7 +637,7 @@ function FullView({
       <div className="max-w-screen-xl mx-auto">
         <Link
           href="/"
-          className="inline-flex items-center gap-1.5 px-10 py-4 text-sm font-bold text-brand-mid hover:text-brand-dark transition-colors"
+          className="inline-flex items-center gap-1.5 px-4 py-4 sm:px-6 lg:px-10 text-sm font-bold text-brand-mid hover:text-brand-dark transition-colors"
         >
           <ArrowLeft className="size-4" />
           Back to Discovery
@@ -647,12 +647,12 @@ function FullView({
       {/* Main content */}
       <div
         className={cn(
-          "max-w-screen-xl mx-auto px-10 pb-16 flex gap-8 h-[calc(100vh-120px)]",
+          "max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-10 pb-16 flex gap-8 lg:h-[calc(100vh-120px)] overflow-x-hidden",
           isCancelled && "opacity-70",
         )}
       >
         {/* ── Left column ─────────────────────────────────────────────────── */}
-        <div className="relative flex-[0_0_65%] min-w-0">
+        <div className="relative w-full min-w-0 lg:flex-[0_0_65%]">
           {/* Scroll indicator track */}
           <div
             ref={leftTrackRef}
@@ -665,7 +665,7 @@ function FullView({
               style={{ top: "var(--thumb-top, 0%)", height: "var(--thumb-height, 20%)" }}
             />
           </div>
-        <div ref={leftColRef} className="h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div ref={leftColRef} className="lg:h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {/* Carousel */}
           <div className="mb-6">
             <ImageCarousel images={event.images ?? []} title={event.title} />
@@ -674,7 +674,7 @@ function FullView({
           {/* Title + badges */}
           <div className="mb-4">
             <div className="flex flex-wrap items-center gap-3 mb-2">
-              <h1 className="font-heading text-brand-dark text-[32px] font-bold leading-tight">
+              <h1 className="font-heading text-brand-dark text-[24px] sm:text-[28px] lg:text-[32px] font-bold leading-tight">
                 {event.title}
               </h1>
               {event.visibility === "private" && <StatusBadge variant="private" />}
@@ -726,7 +726,7 @@ function FullView({
             <h3 className="font-heading text-brand-dark text-lg font-semibold mb-3">
               About this event
             </h3>
-            <p className="text-[15px] leading-[1.7] text-brand-dark whitespace-pre-wrap">
+            <p className="text-[15px] leading-[1.7] text-brand-dark whitespace-pre-wrap break-words">
               {event.description}
             </p>
           </section>
@@ -763,7 +763,7 @@ function FullView({
               <h3 className="font-heading text-brand-dark text-lg font-semibold mb-3">
                 Venue details
               </h3>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 {event.venue_metadata.price && (
                   <div className="flex items-center gap-2 text-sm text-brand-dark">
                     <span className="text-base">🎟️</span>
@@ -867,7 +867,7 @@ function FullView({
                 <button
                   onClick={() => router.push(`/edit-event/${event.id}`)}
                   disabled={isCancelled || isEnded}
-                  className="w-full flex items-center justify-center gap-2 rounded-[10px] border-2 border-brand-dark py-3 text-[15px] font-bold text-brand-dark transition-colors hover:bg-brand-dark/10 disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="w-full flex items-center justify-center gap-2 rounded-[10px] border-2 border-brand-dark py-3 text-[15px] font-bold text-brand-dark transition-colors hover:bg-brand-dark/10 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   <Edit className="size-[18px]" />
                   Edit Event
@@ -875,7 +875,7 @@ function FullView({
                 {isActive && (
                   <button
                     onClick={() => setShowCancelDialog(true)}
-                    className="w-full flex items-center justify-center gap-2 rounded-[10px] border-2 border-danger py-3 text-[15px] font-bold text-danger transition-colors hover:bg-danger/8"
+                    className="w-full flex items-center justify-center gap-2 rounded-[10px] border-2 border-danger py-3 text-[15px] font-bold text-danger transition-colors hover:bg-danger/8 cursor-pointer"
                   >
                     <XCircle className="size-[18px]" />
                     Cancel Event
@@ -971,7 +971,7 @@ function FullView({
               <button
                 onClick={() => { void handleCreateInvite(); }}
                 disabled={inviteLoading || !isActive}
-                className="w-full flex items-center justify-center gap-2 rounded-[10px] border-2 border-brand-dark py-3 text-[15px] font-bold text-brand-dark transition-colors hover:bg-brand-dark/10 disabled:opacity-40 disabled:cursor-not-allowed"
+                className="w-full flex items-center justify-center gap-2 rounded-[10px] border-2 border-brand-dark py-3 text-[15px] font-bold text-brand-dark transition-colors hover:bg-brand-dark/10 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 {inviteLoading ? (
                   <Loader2 className="size-[18px] animate-spin" />
@@ -1062,14 +1062,14 @@ function FullView({
                         <button
                           onClick={() => { void handleAccessRequestAction(req.id, "approved"); }}
                           disabled={requestActionLoading === req.id}
-                          className="rounded-md bg-green-600 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-green-700 disabled:opacity-50 transition-colors"
+                          className="rounded-md bg-green-600 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-green-700 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         >
                           {requestActionLoading === req.id ? "…" : "Approve"}
                         </button>
                         <button
                           onClick={() => { void handleAccessRequestAction(req.id, "rejected"); }}
                           disabled={requestActionLoading === req.id}
-                          className="rounded-md bg-red-500 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-red-600 disabled:opacity-50 transition-colors"
+                          className="rounded-md bg-red-500 px-2.5 py-1 text-[11px] font-bold text-white hover:bg-red-600 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         >
                           Reject
                         </button>

--- a/frontend/src/components/discovery/event-card.tsx
+++ b/frontend/src/components/discovery/event-card.tsx
@@ -129,7 +129,7 @@ export function EventCard({ currentUserId, event, isAuthenticated }: EventCardPr
   return (
     <Link
       href={`/event/${event.id}`}
-      className="bg-brand-surface border-brand-mid-alpha group flex flex-col overflow-hidden rounded-xl border transition-all hover:-translate-y-0.5 hover:shadow-brand-card"
+      className="bg-brand-surface border-brand-mid-alpha group flex h-full flex-col overflow-hidden rounded-xl border transition-all hover:-translate-y-0.5 hover:shadow-brand-card"
     >
       {/* Image */}
       <div className="bg-brand-mid relative aspect-[16/10] w-full">
@@ -158,7 +158,7 @@ export function EventCard({ currentUserId, event, isAuthenticated }: EventCardPr
 
       {/* Body */}
       <div className="flex flex-1 flex-col p-4">
-        <h3 className="font-heading text-brand-dark mb-1 truncate text-[15px] font-bold">{event.title}</h3>
+        <h3 className="font-heading text-brand-dark mb-1 line-clamp-2 text-[15px] font-bold">{event.title}</h3>
         <p className="text-brand-mid mb-2 text-xs font-semibold">
           {formatDateShort(event.start_datetime)} · {formatTime(event.start_datetime)}
         </p>

--- a/frontend/src/components/discovery/list-view.tsx
+++ b/frontend/src/components/discovery/list-view.tsx
@@ -48,7 +48,7 @@ export function ListView({
       </div>
 
       {/* Grid */}
-      <div className="grid flex-1 content-start grid-cols-1 gap-4 px-4 pb-4 sm:grid-cols-2 sm:gap-5 sm:px-6 sm:pb-6 xl:grid-cols-3 xl:gap-6 xl:px-8">
+      <div className="grid flex-1 content-start items-stretch grid-cols-1 gap-4 px-4 pb-4 sm:grid-cols-2 sm:gap-5 sm:px-6 sm:pb-6 xl:grid-cols-3 xl:gap-6 xl:px-8">
         {events.map((event) => (
           <EventCard
             key={event.id}

--- a/frontend/src/components/discovery/map-view.tsx
+++ b/frontend/src/components/discovery/map-view.tsx
@@ -217,7 +217,7 @@ function PopupBody({
                     <button
                       onClick={() => { void handleRequestAccess(); }}
                       disabled={accessStatus === "loading"}
-                      className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-brand-dark px-3 py-1.5 text-xs font-bold text-white transition-all duration-150 hover:bg-brand-dark/85 hover:shadow-md active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-brand-dark px-3 py-1.5 text-xs font-bold text-white transition-all duration-150 hover:bg-brand-dark/85 hover:shadow-md cursor-pointer active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       <Lock className="size-3.5" />
                       {accessStatus === "loading" ? "Sending…" : accessStatus === "error" ? "Try Again" : "Request Access"}

--- a/frontend/src/components/event/comment-section.tsx
+++ b/frontend/src/components/event/comment-section.tsx
@@ -85,6 +85,7 @@ function CommentNode({
   const [replyText, setReplyText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [localReplies, setLocalReplies] = useState<Comment[]>(comment.replies ?? []);
+  const replyInputRef = useRef<HTMLDivElement>(null);
 
   const canReply = isAuthenticated && !disabled && depth < MAX_DEPTH;
 
@@ -137,7 +138,15 @@ function CommentNode({
             </p>
             {canReply && (
               <button
-                onClick={() => setShowReplyInput(!showReplyInput)}
+                onClick={() => {
+                  const next = !showReplyInput;
+                  setShowReplyInput(next);
+                  if (next) {
+                    setTimeout(() => {
+                      replyInputRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+                    }, 50);
+                  }
+                }}
                 className="mt-1 text-[12px] font-bold text-brand-mid hover:text-brand-dark transition-colors flex items-center gap-1"
               >
                 <CornerDownRight className="size-3" />
@@ -149,7 +158,7 @@ function CommentNode({
 
         {/* Reply input */}
         {showReplyInput && (
-          <div className="flex gap-2 items-start mt-2 ml-11">
+          <div ref={replyInputRef} className="flex gap-2 items-start mt-2 ml-11">
             <textarea
               value={replyText}
               onChange={(e) => setReplyText(e.target.value)}
@@ -258,7 +267,7 @@ export function CommentSection({
   }
 
   return (
-    <div ref={scrollRef} className="flex flex-col gap-4">
+    <div ref={scrollRef} className="flex flex-col gap-4 pb-24">
       <h3 className="font-heading text-brand-dark text-lg font-semibold">
         Comments{!loading && <span className="text-brand-mid text-sm font-normal ml-1">({totalCount})</span>}
       </h3>

--- a/frontend/src/components/events/event-editor.tsx
+++ b/frontend/src/components/events/event-editor.tsx
@@ -433,6 +433,15 @@ function SummaryCard({
   );
 }
 
+function isAtLeast18(dob: string): boolean {
+  const birth = new Date(dob);
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+  return age >= 18;
+}
+
 export function EventEditor({ eventId, mode }: EventEditorProps) {
   const router = useRouter();
   const { user } = useAuth();
@@ -1742,22 +1751,36 @@ export function EventEditor({ eventId, mode }: EventEditorProps) {
                         </div>
                       </div>
 
-                      <div className="border-border/80 bg-background/70 rounded-lg border p-5">
-                        <div className="flex items-center gap-3">
-                          <Checkbox
-                            checked={formValues.isAgeRestricted}
-                            onCheckedChange={(checked) =>
-                              patchFormValues({ isAgeRestricted: toBoolean(checked) })
-                            }
-                          />
-                          <div>
-                            <p className="text-base font-semibold">18+ event</p>
-                            <p className="text-muted-foreground text-sm leading-6">
-                              Only adults aged 18 and over can view and attend this event.
-                            </p>
+                      {(() => {
+                        const hasDob = Boolean(user?.date_of_birth);
+                        const canCreate18Plus = hasDob && isAtLeast18(user!.date_of_birth!);
+                        const ageGuardMsg = !hasDob
+                          ? "Set your date of birth in profile settings to enable this option."
+                          : "You must be 18 or older to create an age-restricted event.";
+                        return (
+                          <div className="border-border/80 bg-background/70 rounded-lg border p-5">
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                checked={formValues.isAgeRestricted}
+                                disabled={!canCreate18Plus}
+                                onCheckedChange={(checked) =>
+                                  patchFormValues({ isAgeRestricted: toBoolean(checked) })
+                                }
+                              />
+                              <div>
+                                <p className="text-base font-semibold">18+ event</p>
+                                {canCreate18Plus ? (
+                                  <p className="text-muted-foreground text-sm leading-6">
+                                    Only adults aged 18 and over can view and attend this event.
+                                  </p>
+                                ) : (
+                                  <p className="text-sm leading-6 text-amber-600">{ageGuardMsg}</p>
+                                )}
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      </div>
+                        );
+                      })()}
 
                       <div className="border-border/80 bg-background/70 rounded-lg border p-5">
                         <p className="text-muted-foreground text-sm leading-6">

--- a/frontend/src/components/profile/host-profile-page.tsx
+++ b/frontend/src/components/profile/host-profile-page.tsx
@@ -77,7 +77,7 @@ function RatingStars({
             onClick={() => onSelect?.(value)}
             className={cn(
               "rounded-md p-1.5 transition-colors",
-              onSelect && !disabled && "hover:bg-brand-mid-alpha/60",
+              onSelect && !disabled && "cursor-pointer hover:bg-brand-mid-alpha/60",
               disabled && "cursor-default",
             )}
             aria-label={`Rate ${value} stars`}
@@ -382,7 +382,7 @@ export function HostProfilePage() {
                       type="button"
                       onClick={() => setActiveTab(tab.key)}
                       className={cn(
-                        "rounded-[18px] px-5 py-3 text-sm font-semibold transition-colors",
+                        "rounded-[18px] px-5 py-3 text-sm font-semibold transition-colors cursor-pointer",
                         activeTab === tab.key
                           ? "bg-brand-bg text-brand-dark shadow-[0_6px_20px_-16px_rgba(73,54,40,0.55)]"
                           : "text-brand-mid hover:bg-brand-bg/70 hover:text-brand-dark",

--- a/frontend/src/components/profile/my-profile-page.tsx
+++ b/frontend/src/components/profile/my-profile-page.tsx
@@ -111,7 +111,7 @@ function PrivacyToggle({
         aria-checked={isEnabled}
         onClick={() => onChange(isEnabled ? "private" : "public")}
         className={cn(
-          "relative inline-flex h-8 w-[58px] shrink-0 rounded-full border transition-colors",
+          "relative inline-flex h-8 w-[58px] shrink-0 rounded-full border transition-colors cursor-pointer",
           isEnabled ? "border-brand-mid bg-brand-mid" : "border-brand-mid/20 bg-brand-bg",
         )}
       >
@@ -688,7 +688,7 @@ export function MyProfilePage() {
                       type="button"
                       onClick={() => setActiveSection(section.key)}
                       className={cn(
-                        "flex min-w-[190px] items-center gap-3 rounded-[20px] px-4 py-3 text-left transition-colors",
+                        "flex min-w-[190px] items-center gap-3 rounded-[20px] px-4 py-3 text-left transition-colors cursor-pointer",
                         isActive
                           ? "bg-brand-dark text-white shadow-[0_14px_26px_-20px_rgba(73,54,40,0.8)]"
                           : "text-brand-dark hover:bg-brand-bg",
@@ -990,7 +990,7 @@ export function MyProfilePage() {
                         type="button"
                         onClick={() => setEventsTab(tab.key)}
                         className={cn(
-                          "inline-flex items-center gap-2 border-b-[3px] px-6 py-3 text-sm transition-colors",
+                          "inline-flex items-center gap-2 border-b-[3px] px-6 py-3 text-sm transition-colors cursor-pointer",
                           eventsTab === tab.key
                             ? "border-brand-dark font-bold text-brand-dark"
                             : "border-transparent font-medium text-brand-mid hover:text-brand-dark",


### PR DESCRIPTION
- Block underage/no-DOB users from enabling 18+ toggle in event creation (issue #199)
- Equal-height event cards in list view via items-stretch + h-full + line-clamp-2 (issue #200)
- Add cursor-pointer to interactive elements across event detail, map popup, and profile pages (issue #202)
- Add pb-24 and scrollIntoView to comment section so reply input is always reachable (issue #203)
- Fix responsive layout on event detail page: responsive padding, title size, description break-words, venue grid, and overflow-x-hidden (issue #206)

Closes #199, Closes #200, Closes #202, Closes #203, Closes #206