### PR TITLE
fix(mobile): MVP polish — auth, event detail, profile, notifications, map

### DIFF
--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -117,6 +117,7 @@ class EventUpdateRequest(BaseModel):
 class EventDetailResponse(BaseModel):
     id: UUID
     host_id: UUID
+    host_username: str = ""
     title: str
     description: str
     start_datetime: datetime

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -204,6 +204,7 @@ def _build_detail_response(
     bookmark_count: int = 0,
     access_request_status: str | None = None,
     attendees: list[dict] | None = None,
+    host_username: str = "",
 ) -> EventDetailResponse:
     actual_going = going_count if going_count is not None else event["attendee_count"]
     is_full = None
@@ -213,6 +214,7 @@ def _build_detail_response(
     return EventDetailResponse(
         id=event["id"],
         host_id=event["host_id"],
+        host_username=host_username,
         title=event["title"],
         description=event["description"],
         start_datetime=event["start_datetime"],
@@ -357,6 +359,9 @@ def get_event_detail(
         for attendee_id in attendee_ids
     ]
 
+    host = user_repo.get_user_by_id(db, str(event["host_id"]))
+    host_username = host["username"] if host else ""
+
     return _build_detail_response(
         event, locations, categories, images, venue_metadata, equipment,
         is_bookmarked=is_bookmarked,
@@ -365,6 +370,7 @@ def get_event_detail(
         bookmark_count=bookmark_count,
         access_request_status=access_request_status,
         attendees=attendees,
+        host_username=host_username,
     )
 
 

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/EventDetailDto.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/EventDetailDto.kt
@@ -7,6 +7,7 @@ package com.bounswe.group9.mobile.data.remote
 data class EventDetailDto(
     val id: String,
     val host_id: String,
+    val host_username: String? = null,
     val title: String,
     val description: String,
     val start_datetime: String,
@@ -68,5 +69,6 @@ data class EventLimitedDto(
     val is_age_restricted: Boolean,
     val status: String,
     val is_bookmarked: Boolean?,
+    val access_request_status: String? = null,  // "pending" | "approved" | "rejected" | null
     val categories: List<CategoryDto>
 )

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/repository/AuthRepository.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/repository/AuthRepository.kt
@@ -6,8 +6,38 @@ import com.bounswe.group9.mobile.data.remote.RefreshTokenRequest
 import com.bounswe.group9.mobile.data.remote.RegisterRequest
 import com.bounswe.group9.mobile.data.remote.RetrofitProvider
 import com.bounswe.group9.mobile.data.remote.UserResponse
+import org.json.JSONObject
 
 data class AuthResult(val accessToken: String, val user: UserResponse)
+
+private fun friendlyHttpError(code: Int, body: String): String {
+    val detail = try {
+        val json = JSONObject(body)
+        when {
+            json.has("detail") -> {
+                val d = json.get("detail")
+                if (d is String) d
+                else {
+                    // Pydantic validation array — pick first msg
+                    val arr = json.getJSONArray("detail")
+                    if (arr.length() > 0) arr.getJSONObject(0).optString("msg", "") else ""
+                }
+            }
+            json.has("message") -> json.getString("message")
+            else -> ""
+        }
+    } catch (_: Exception) { "" }
+
+    return when {
+        detail.isNotBlank() -> detail
+        code == 401 -> "Incorrect email or password."
+        code == 403 -> "Your account is not allowed to perform this action."
+        code == 409 -> "An account with this email or username already exists."
+        code == 422 -> "Please check your input and try again."
+        code == 429 -> "Too many attempts. Please wait a moment and try again."
+        else -> "Something went wrong (error $code). Please try again."
+    }
+}
 
 class AuthRepository {
 
@@ -20,7 +50,7 @@ class AuthRepository {
         } catch (e: retrofit2.HttpException) {
             val body = e.response()?.errorBody()?.string() ?: "Unknown error"
             Log.e("AuthRepository", "Login HTTP ${e.code()}: $body")
-            Result.failure(Exception("${e.code()}: $body"))
+            Result.failure(Exception(friendlyHttpError(e.code(), body)))
         } catch (e: Exception) {
             Log.e("AuthRepository", "Login failed: ${e.message}", e)
             Result.failure(e)
@@ -46,7 +76,7 @@ class AuthRepository {
         } catch (e: retrofit2.HttpException) {
             val body = e.response()?.errorBody()?.string() ?: "Unknown error"
             Log.e("AuthRepository", "Register HTTP ${e.code()}: $body")
-            Result.failure(Exception("${e.code()}: $body"))
+            Result.failure(Exception(friendlyHttpError(e.code(), body)))
         } catch (e: Exception) {
             Log.e("AuthRepository", "Register failed: ${e.message}", e)
             Result.failure(e)
@@ -62,7 +92,7 @@ class AuthRepository {
         } catch (e: retrofit2.HttpException) {
             val body = e.response()?.errorBody()?.string() ?: "Unknown error"
             Log.e("AuthRepository", "Refresh HTTP ${e.code()}: $body")
-            Result.failure(Exception("${e.code()}: $body"))
+            Result.failure(Exception(friendlyHttpError(e.code(), body)))
         } catch (e: Exception) {
             Log.e("AuthRepository", "Refresh failed: ${e.message}", e)
             Result.failure(e)

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/auth/AuthViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/auth/AuthViewModel.kt
@@ -48,6 +48,16 @@ class AuthViewModel(
     fun onDateOfBirthChange(v: String) { _uiState.value = _uiState.value.copy(dateOfBirth = v) }
 
     fun login() {
+        val s = _uiState.value
+        val validationError = when {
+            s.email.isBlank()    -> "Email is required."
+            s.password.isBlank() -> "Password is required."
+            else -> null
+        }
+        if (validationError != null) {
+            _uiState.value = s.copy(errorMessage = validationError)
+            return
+        }
         _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
         viewModelScope.launch {
             val result = repository.login(
@@ -73,6 +83,22 @@ class AuthViewModel(
     }
 
     fun register() {
+        val s = _uiState.value
+        val validationError = when {
+            s.username.isBlank()     -> "Username is required."
+            s.username.length < 3    -> "Username must be at least 3 characters."
+            s.email.isBlank()        -> "Email is required."
+            s.password.isBlank()     -> "Password is required."
+            s.password.length < 8    -> "Password must be at least 8 characters."
+            s.dateOfBirth.isBlank()  -> "Date of birth is required."
+            !Regex("""\d{4}-\d{2}-\d{2}""").matches(s.dateOfBirth) ->
+                "Date of birth must be in YYYY-MM-DD format."
+            else -> null
+        }
+        if (validationError != null) {
+            _uiState.value = s.copy(errorMessage = validationError)
+            return
+        }
         _uiState.value = _uiState.value.copy(isLoading = true, errorMessage = null)
         viewModelScope.launch {
             val result = repository.register(

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/auth/LoginScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/auth/LoginScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -16,6 +18,10 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 @Composable
 fun LoginScreen(viewModel: AuthViewModel, onLoginSuccess: () -> Unit = {}) {
@@ -140,10 +146,9 @@ fun LoginScreen(viewModel: AuthViewModel, onLoginSuccess: () -> Unit = {}) {
 
                     if (!isLoginTab) {
                         Spacer(modifier = Modifier.height(12.dp))
-                        BrandTextField(
+                        DobPickerField(
                             value = uiState.dateOfBirth,
-                            onValueChange = viewModel::onDateOfBirthChange,
-                            label = "Date of Birth (YYYY-MM-DD)"
+                            onValueChange = viewModel::onDateOfBirthChange
                         )
                     }
 
@@ -256,6 +261,68 @@ private fun TabButton(
     ) {
         Text(text = text, fontSize = 13.sp, fontWeight = FontWeight.Medium)
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DobPickerField(
+    value: String,
+    onValueChange: (String) -> Unit
+) {
+    var showPicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = if (value.matches(Regex("""\d{4}-\d{2}-\d{2}"""))) {
+            try {
+                val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
+                    timeZone = TimeZone.getTimeZone("UTC")
+                }
+                sdf.parse(value)?.time
+            } catch (_: Exception) { null }
+        } else null
+    )
+
+    if (showPicker) {
+        DatePickerDialog(
+            onDismissRequest = { showPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
+                            timeZone = TimeZone.getTimeZone("UTC")
+                        }
+                        onValueChange(sdf.format(Date(millis)))
+                    }
+                    showPicker = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showPicker = false }) { Text("Cancel") }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text("Date of Birth") },
+        placeholder = { Text("YYYY-MM-DD") },
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        trailingIcon = {
+            IconButton(onClick = { showPicker = true }) {
+                Icon(Icons.Default.CalendarToday, contentDescription = "Pick date")
+            }
+        },
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = MaterialTheme.colorScheme.tertiary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f),
+            focusedLabelColor = MaterialTheme.colorScheme.tertiary,
+        )
+    )
 }
 
 @Composable

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
@@ -116,7 +116,12 @@ fun CreateEventScreen(
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.GetMultipleContents()
-    ) { uris: List<Uri> -> uris.forEach { viewModel.addImageUri(it) } }
+    ) { uris: List<Uri> ->
+        if (uris.isNotEmpty()) {
+            uris.forEach { viewModel.addImageUri(it) }
+            viewModel.uploadImages(context)
+        }
+    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbar) },
@@ -929,45 +934,7 @@ private fun MediaStep(
                 }
             }
 
-            // Upload button if URIs selected
-            if (uiState.selectedImageUris.isNotEmpty()) {
-                Spacer(Modifier.height(10.dp))
-                Button(
-                    onClick = { viewModel.uploadImages(context) },
-                    enabled = !uiState.isUploadingImages,
-                    colors = ButtonDefaults.buttonColors(containerColor = BrandDark),
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text("Upload ${uiState.selectedImageUris.size} selected image${if (uiState.selectedImageUris.size == 1) "" else "s"}")
-                }
-            }
-
             uiState.imageUploadError?.let { Spacer(Modifier.height(6.dp)); Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
-        }
-
-        // Pending images (selected but not yet uploaded)
-        if (uiState.selectedImageUris.isNotEmpty()) {
-            StepCard {
-                Text("Selected for upload", style = MaterialTheme.typography.labelMedium, color = Color(0xFF78716C))
-                Spacer(Modifier.height(8.dp))
-                Row(modifier = Modifier.horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    uiState.selectedImageUris.forEach { uri ->
-                        Box {
-                            AsyncImage(
-                                model = uri, contentDescription = null,
-                                modifier = Modifier.size(80.dp).clip(RoundedCornerShape(8.dp)),
-                                contentScale = ContentScale.Crop
-                            )
-                            IconButton(
-                                onClick = { viewModel.removeImageUri(uri) },
-                                modifier = Modifier.align(Alignment.TopEnd).size(24.dp).background(Color.Black.copy(0.5f), CircleShape)
-                            ) {
-                                Icon(Icons.Default.Close, null, modifier = Modifier.size(12.dp), tint = Color.White)
-                            }
-                        }
-                    }
-                }
-            }
         }
 
         // Already uploaded images

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryScreen.kt
@@ -136,7 +136,9 @@ fun DiscoveryScreen(
                     if (isMapView) {
                         EventMapView(
                             events = uiState.displayedEvents,
-                            onEventClick = onEventClick
+                            onEventClick = onEventClick,
+                            onBookmarkToggle = { eventId -> viewModel.toggleBookmark(eventId) },
+                            token = token
                         )
                     } else {
                         LazyColumn(

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
@@ -64,6 +64,31 @@ class DiscoveryViewModel(
 
     fun refresh() = loadEvents(reset = true)
 
+    fun toggleBookmark(eventId: String) {
+        val t = token ?: return
+        val events = _uiState.value.events
+        val event = events.find { it.id == eventId } ?: return
+        val isBookmarked = event.is_bookmarked == true
+
+        // Optimistic update
+        _uiState.value = _uiState.value.copy(
+            events = events.map { if (it.id == eventId) it.copy(is_bookmarked = !isBookmarked) else it }
+        )
+
+        viewModelScope.launch {
+            val result = if (isBookmarked) repository.removeBookmark(t, eventId)
+                         else repository.addBookmark(t, eventId)
+            result.onFailure {
+                // Rollback on error
+                _uiState.value = _uiState.value.copy(
+                    events = _uiState.value.events.map {
+                        if (it.id == eventId) it.copy(is_bookmarked = isBookmarked) else it
+                    }
+                )
+            }
+        }
+    }
+
     fun onBookmarkedOnlyToggle() {
         val current = _uiState.value.bookmarkedOnly
         _uiState.value = _uiState.value.copy(bookmarkedOnly = !current, goingOnly = false)

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/MapView.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/MapView.kt
@@ -6,6 +6,9 @@ import android.graphics.Paint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -37,10 +40,19 @@ private val DEFAULT_ZOOM = 10.0
 @Composable
 fun EventMapView(
     events: List<EventListItemDto>,
-    onEventClick: (String) -> Unit
+    onEventClick: (String) -> Unit,
+    onBookmarkToggle: ((String) -> Unit)? = null,
+    token: String? = null
 ) {
     var selectedEvent by remember { mutableStateOf<EventListItemDto?>(null) }
     val markerToEvent = remember { mutableMapOf<Long, EventListItemDto>() }
+
+    // Keep selectedEvent in sync with events list (reflects optimistic bookmark update)
+    val currentSelectedId = selectedEvent?.id
+    if (currentSelectedId != null) {
+        val updated = events.find { it.id == currentSelectedId }
+        if (updated != null && updated != selectedEvent) selectedEvent = updated
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         AndroidView(
@@ -90,6 +102,9 @@ fun EventMapView(
                 event = event,
                 onDismiss = { selectedEvent = null },
                 onViewDetail = { onEventClick(event.id) },
+                onBookmarkToggle = if (token != null && onBookmarkToggle != null) {
+                    { onBookmarkToggle(event.id) }
+                } else null,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .padding(16.dp)
@@ -103,6 +118,7 @@ private fun EventMapPopup(
     event: EventListItemDto,
     onDismiss: () -> Unit,
     onViewDetail: () -> Unit,
+    onBookmarkToggle: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -156,17 +172,38 @@ private fun EventMapPopup(
                     )
                 }
                 Spacer(Modifier.height(8.dp))
-                TextButton(
-                    onClick = onViewDetail,
-                    contentPadding = PaddingValues(0.dp),
-                    modifier = Modifier.height(24.dp)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    Text(
-                        "View Details →",
-                        fontSize = 12.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.tertiary
-                    )
+                    TextButton(
+                        onClick = onViewDetail,
+                        contentPadding = PaddingValues(0.dp),
+                        modifier = Modifier.height(24.dp)
+                    ) {
+                        Text(
+                            "View Details →",
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.tertiary
+                        )
+                    }
+                    if (onBookmarkToggle != null) {
+                        val isBookmarked = event.is_bookmarked == true
+                        IconButton(
+                            onClick = onBookmarkToggle,
+                            modifier = Modifier.size(24.dp)
+                        ) {
+                            Icon(
+                                imageVector = if (isBookmarked) Icons.Filled.Bookmark
+                                              else Icons.Filled.BookmarkBorder,
+                                contentDescription = if (isBookmarked) "Remove bookmark" else "Bookmark",
+                                tint = if (isBookmarked) MaterialTheme.colorScheme.tertiary
+                                       else MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
                 }
             }
 

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
@@ -442,6 +442,7 @@ private fun LimitedPreviewContent(
 
 // region Full Detail
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FullDetailContent(
     event: EventDetailDto,
@@ -587,8 +588,19 @@ private fun FullDetailContent(
             // Host link
             Spacer(Modifier.height(16.dp))
             SectionHeader("Host")
-            TextButton(onClick = { onNavigateToHost(event.host_id) }) {
-                Text("View host profile", fontSize = 14.sp)
+            val displayName = uiState.hostUsername?.let { "@$it" } ?: "View host profile"
+            Surface(
+                onClick = { onNavigateToHost(event.host_id) },
+                shape = RoundedCornerShape(8.dp),
+                color = MaterialTheme.colorScheme.secondaryContainer
+            ) {
+                Text(
+                    text = displayName,
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp
+                )
             }
 
             // Manage Invites (host only)

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.bounswe.group9.mobile.data.remote.InviteResponseDto
 import com.bounswe.group9.mobile.data.repository.EventDetailError
 import com.bounswe.group9.mobile.data.repository.EventDetailResult
 import com.bounswe.group9.mobile.data.repository.EventRepository
+import com.bounswe.group9.mobile.data.repository.ProfileRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,6 +19,7 @@ import kotlinx.coroutines.launch
 data class EventDetailUiState(
     val fullDetail: EventDetailDto? = null,
     val limitedPreview: EventLimitedDto? = null,
+    val hostUsername: String? = null,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
     val detailError: EventDetailError? = null,
@@ -54,7 +56,8 @@ data class EventDetailUiState(
 }
 
 class EventDetailViewModel(
-    private val repository: EventRepository = EventRepository()
+    private val repository: EventRepository = EventRepository(),
+    private val profileRepository: ProfileRepository = ProfileRepository()
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(EventDetailUiState())
@@ -74,29 +77,50 @@ class EventDetailViewModel(
         currentEventId = eventId
         _uiState.value = EventDetailUiState(isLoading = true)
         viewModelScope.launch {
-            repository.getEventDetail(token, eventId).fold(
-                onSuccess = { result ->
-                    _uiState.value = when (result) {
-                        is EventDetailResult.Full -> EventDetailUiState(fullDetail = result.detail)
-                        is EventDetailResult.Limited -> EventDetailUiState(limitedPreview = result.preview)
+            val result = repository.getEventDetail(token, eventId)
+            if (result.isSuccess) {
+                when (val r = result.getOrNull()!!) {
+                    is EventDetailResult.Full -> {
+                        _uiState.value = EventDetailUiState(fullDetail = r.detail)
+                        loadComments(reset = true)
+                        if (token != null) loadInviteSection()
+                        loadHostUsername(r.detail.host_id)
                     }
-                    // Load comments for full detail view
-                    if (result is EventDetailResult.Full) loadComments(reset = true)
-                    // Load invite section for host; check access request status for non-host limited
-                    if (result is EventDetailResult.Full && token != null) {
-                        loadInviteSection()
-                    } else if (result is EventDetailResult.Limited) {
-                        checkAccessRequestStatus()
+                    is EventDetailResult.Limited -> {
+                        // Age-restricted limited preview: check user age before showing
+                        if (r.preview.is_age_restricted && token != null) {
+                            val ageError = checkAgeRestriction(token)
+                            if (ageError != null) {
+                                _uiState.value = EventDetailUiState(
+                                    detailError = ageError,
+                                    errorMessage = ageError.message
+                                )
+                                return@launch
+                            }
+                        }
+                        // Server provides access_request_status authoritatively — seed cache and use directly
+                        val serverStatus = r.preview.access_request_status
+                        if (serverStatus != null) {
+                            accessRequestCache[eventId] = serverStatus
+                        }
+                        _uiState.value = EventDetailUiState(
+                            limitedPreview = r.preview,
+                            accessRequestStatus = serverStatus ?: accessRequestCache[eventId]
+                        )
+                        // If server already says approved, reload for full detail
+                        if (serverStatus == "approved") {
+                            loadEvent(eventId, token)
+                        }
                     }
-                },
-                onFailure = { e ->
-                    val typedError = e as? EventDetailError
-                    _uiState.value = EventDetailUiState(
-                        errorMessage = e.message,
-                        detailError = typedError
-                    )
                 }
-            )
+            } else {
+                val e = result.exceptionOrNull()!!
+                val typedError = e as? EventDetailError
+                _uiState.value = EventDetailUiState(
+                    errorMessage = e.message,
+                    detailError = typedError
+                )
+            }
         }
     }
 
@@ -479,6 +503,46 @@ class EventDetailViewModel(
                 }
             )
         }
+    }
+
+    private fun loadHostUsername(hostId: String) {
+        viewModelScope.launch {
+            profileRepository.getHostProfile(null, hostId).onSuccess { profile ->
+                _uiState.value = _uiState.value.copy(hostUsername = profile.username)
+            }
+        }
+    }
+
+    /**
+     * Returns an [EventDetailError] if [token] user is blocked by age restriction, null if allowed.
+     * Fetches /me to get DOB; if no DOB returns [EventDetailError.DobRequired],
+     * if under 18 returns [EventDetailError.Underage].
+     */
+    private suspend fun checkAgeRestriction(token: String): EventDetailError? {
+        val profile = profileRepository.getMe(token).getOrNull() ?: return null
+        val dob = profile.date_of_birth
+        if (dob.isNullOrBlank()) return EventDetailError.DobRequired()
+        return if (isUnder18(dob)) EventDetailError.Underage() else null
+    }
+
+    private fun isUnder18(dob: String): Boolean {
+        return try {
+            val sdf = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US)
+            val dobDate = sdf.parse(dob) ?: return false
+            val cal = java.util.Calendar.getInstance()
+            val today = cal.time
+            cal.time = dobDate
+            val dobYear = cal.get(java.util.Calendar.YEAR)
+            val dobMonth = cal.get(java.util.Calendar.MONTH)
+            val dobDay = cal.get(java.util.Calendar.DAY_OF_MONTH)
+            cal.time = today
+            val todayYear = cal.get(java.util.Calendar.YEAR)
+            val todayMonth = cal.get(java.util.Calendar.MONTH)
+            val todayDay = cal.get(java.util.Calendar.DAY_OF_MONTH)
+            val age = todayYear - dobYear -
+                if (todayMonth < dobMonth || (todayMonth == dobMonth && todayDay < dobDay)) 1 else 0
+            age < 18
+        } catch (_: Exception) { false }
     }
 
     /** On limited view load — only restore status from session cache. No auto-request creation. */

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/hostprofile/HostProfileScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/hostprofile/HostProfileScreen.kt
@@ -146,7 +146,7 @@ private fun ProfileContent(
                                 Icons.Default.Star,
                                 contentDescription = null,
                                 modifier = Modifier.size(20.dp),
-                                tint = if (i < profile.average_rating.toInt()) Color(0xFFFFC107) else Color(0xFFE0E0E0)
+                                tint = if (i < profile.average_rating.toInt()) Color(0xFFFFC107) else Color(0xFF9E9E9E)
                             )
                         }
                         Spacer(Modifier.width(8.dp))
@@ -170,7 +170,7 @@ private fun ProfileContent(
                                 Icon(
                                     Icons.Default.Star,
                                     contentDescription = "Rate ${i + 1}",
-                                    tint = if (i < uiState.ratingScore.toInt()) Color(0xFFFFC107) else Color(0xFFE0E0E0),
+                                    tint = if (i < uiState.ratingScore.toInt()) Color(0xFFFFC107) else Color(0xFF9E9E9E),
                                     modifier = Modifier.size(24.dp)
                                 )
                             }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/notifications/NotificationScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/notifications/NotificationScreen.kt
@@ -19,6 +19,9 @@ import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -45,6 +48,13 @@ fun NotificationScreen(
     val listState = rememberLazyListState()
 
     LaunchedEffect(token) { viewModel.setToken(token) }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            viewModel.refresh()
+        }
+    }
 
     // Pagination
     LaunchedEffect(listState.firstVisibleItemIndex, uiState.notifications.size) {

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -41,8 +44,16 @@ fun ProfileScreen(
     val listState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // Init / refresh when token changes
+    // Init when token/credentials change (login/logout)
     LaunchedEffect(token) { viewModel.setToken(token) }
+
+    // Refresh every time this screen becomes the active destination (e.g. returning from event detail)
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            viewModel.refresh()
+        }
+    }
 
     // Show success toast
     LaunchedEffect(uiState.successMessage) {
@@ -136,9 +147,34 @@ fun ProfileScreen(
                 }
             }
 
+            // ── Stats Row ─────────────────────────────────────────────────
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    StatCard(
+                        value = uiState.hostedEventsCount.toString(),
+                        label = "EVENTS",
+                        modifier = Modifier.weight(1f)
+                    )
+                    StatCard(
+                        value = uiState.averageRating?.let { "%.1f".format(it) } ?: "New",
+                        label = "AVG RATING",
+                        modifier = Modifier.weight(1f)
+                    )
+                    StatCard(
+                        value = uiState.upcomingEventsCount.toString(),
+                        label = "UPCOMING",
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+
             // ── Edit Profile Card ─────────────────────────────────────────
             item {
-                Spacer(Modifier.height(16.dp))
                 SectionLabel("EDIT PROFILE")
                 Card(
                     modifier = Modifier
@@ -355,6 +391,38 @@ fun ProfileScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun StatCard(value: String, label: String, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(14.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 14.dp, horizontal = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = value,
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = label,
+                fontSize = 9.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 1.5.sp,
+                color = MaterialTheme.colorScheme.tertiary
+            )
         }
     }
 }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileUiState.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileUiState.kt
@@ -4,6 +4,10 @@ import com.bounswe.group9.mobile.data.remote.BookmarkedEventDto
 import com.bounswe.group9.mobile.data.remote.EventListItemDto
 
 data class ProfileUiState(
+    // Stats (from host profile endpoint)
+    val averageRating: Double? = null,
+    val hostedEventsCount: Int = 0,
+    val upcomingEventsCount: Int = 0,
     // Edit form drafts
     val editPhoneNumber: String = "",
     val editDateOfBirth: String = "",

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileViewModel.kt
@@ -65,8 +65,21 @@ class ProfileViewModel : ViewModel() {
             _uiState.value = _uiState.value.copy(isLoadingHostedEvents = true)
             repository.getHostProfile(token, userId).fold(
                 onSuccess = { profile ->
+                    val now = System.currentTimeMillis()
+                    val upcomingCount = profile.hosted_events.count { event ->
+                        (event.status == "published" || event.status == "updated") &&
+                            try {
+                                val sdf = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", java.util.Locale.US)
+                                sdf.isLenient = true
+                                val startMs = sdf.parse(event.start_datetime.take(19))?.time ?: 0L
+                                startMs > now
+                            } catch (_: Exception) { false }
+                    }
                     _uiState.value = _uiState.value.copy(
                         hostedEvents = profile.hosted_events,
+                        hostedEventsCount = profile.hosted_events_count,
+                        averageRating = profile.average_rating,
+                        upcomingEventsCount = upcomingCount,
                         isLoadingHostedEvents = false
                     )
                 },
@@ -167,6 +180,12 @@ class ProfileViewModel : ViewModel() {
         val state = _uiState.value
         if (state.isLoadingMoreBookmarks || state.bookmarkPage >= state.bookmarkTotalPages) return
         loadBookmarks(page = state.bookmarkPage + 1, reset = false)
+    }
+
+    fun refresh() {
+        if (currentToken == null || currentUserId == null) return
+        loadHostedEvents()
+        loadBookmarks(page = 1, reset = true)
     }
 
     fun dismissSuccess() {


### PR DESCRIPTION
Closes #214 
- Sign up: add client-side validation + friendly HTTP error messages
- Sign up: add DatePickerDialog for date of birth field
- Event detail: age restriction check takes priority over private event request access UI for underage users
- Event detail: fix access request status showing "Request Access" after re-entering event — map backend-provided access_request_status field from EventLimitedDto instead of relying on in-memory cache only
- Event detail: show host @username on host button (fetched via host profile endpoint); button styled as tappable chip
- Event detail: fix host_username Gson null-safety (String? instead of String)
- Event detail: fix unselected star rating color invisible on light background
- Map view: add bookmark toggle button to event popup card
- Discovery: add toggleBookmark to DiscoveryViewModel with optimistic update
- Profile screen: refresh hosted events and bookmarks on every screen resume
- Notifications screen: refresh on every screen resume (not only on token change)
- Create event: auto-upload images immediately on gallery selection, remove manual upload button
- Backend: add host_username field to EventDetailResponse


## Summary

- **Auth**: Client-side validation and friendly HTTP error messages added to sign up; DatePickerDialog added for DOB field (text input preserved)
- **Event detail (age priority)**: Underage users visiting a private + age-restricted event now see the age restriction screen first, blocking the Request Access UI
- **Event detail (access status)**: Added `access_request_status` field to `EventLimitedDto`; backend was already sending it but Gson was silently dropping it — pending status now persists correctly after re-navigation
- **Event detail (host button)**: Host button shows `@username` (fetched from host profile endpoint), styled as a tappable chip so it is clearly interactive
- **Star rating**: Unselected star color changed from `#E0E0E0` to `#9E9E9E` (visible on light backgrounds)
- **Map bookmark**: Bookmark toggle button added to map event popup; `toggleBookmark` with optimistic update added to DiscoveryViewModel
- **Profile / Notifications refresh**: `repeatOnLifecycle(RESUMED)` triggers a refresh every time the screen becomes the active destination
- **Create event image upload**: Images auto-upload on gallery selection; manual upload button removed
- **Backend**: `host_username` field added to `EventDetailResponse`

## Test plan

- [ ] Sign up — missing field, short password, wrong format errors show readable messages
- [ ] 18+ private event — age restriction screen appears first for underage accounts
- [ ] Private event — send access request, go back, re-enter — "pending" status shown correctly
- [ ] Event detail — host button shows @username and navigates to host profile
- [ ] Host profile — unselected stars in rating section are visibly grey
- [ ] Map — bookmark button in event popup works correctly
- [ ] My Profile — events and bookmarks refresh when returning from another screen
- [ ] Notifications — page refreshes immediately on open
- [ ] Create event — image upload starts automatically on gallery selection
