### PR TITLE
fix: restrict host rating to users who attended an ended event

### DIFF
--- a/backend/app/models/profile.py
+++ b/backend/app/models/profile.py
@@ -25,3 +25,4 @@ class HostProfileResponse(BaseModel):
     average_rating: float | None = None
     hosted_events_count: int
     hosted_events: list[EventListItemResponse]
+    can_rate: bool = False

--- a/backend/app/repositories/attendance.py
+++ b/backend/app/repositories/attendance.py
@@ -60,3 +60,18 @@ def get_attendance_status_for_events(db: Client, user_id: str, event_ids: list[s
     )
 
     return {row["event_id"]: row["status"] for row in (result.data or [])}
+
+
+def has_attended_ended_event_by_host(db: Client, user_id: str, host_id: str) -> bool:
+    """Returns True if user_id has a 'going' attendance on at least one ended event hosted by host_id."""
+    result = (
+        db.table("attendances")
+        .select("event_id, events!inner(host_id, status)")
+        .eq("user_id", user_id)
+        .eq("status", "going")
+        .eq("events.host_id", host_id)
+        .eq("events.status", "ended")
+        .limit(1)
+        .execute()
+    )
+    return bool(result.data)

--- a/backend/app/services/profile.py
+++ b/backend/app/services/profile.py
@@ -5,6 +5,7 @@ from supabase import Client
 
 from app.models.profile import HostProfileResponse, ProfileUpdateRequest
 from app.models.user import UserResponse
+from app.repositories import attendance as attendance_repo
 from app.repositories import event as event_repo
 from app.repositories import profile as profile_repo
 from app.repositories import rating as rating_repo
@@ -62,6 +63,12 @@ def get_host_profile(db: Client, target_user_id: str, current_user_id: str | Non
     if user.get("phone_visibility") is True:
         phone_number = user.get("phone_number")
 
+    can_rate = (
+        current_user_id is not None
+        and not is_owner
+        and attendance_repo.has_attended_ended_event_by_host(db, current_user_id, target_user_id)
+    )
+
     return HostProfileResponse(
         id=user["id"],
         username=user["username"],
@@ -70,6 +77,7 @@ def get_host_profile(db: Client, target_user_id: str, current_user_id: str | Non
         average_rating=rating_stats["average"],
         hosted_events_count=len(items),
         hosted_events=items,
+        can_rate=can_rate,
     )
 
 

--- a/backend/app/services/rating.py
+++ b/backend/app/services/rating.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, status
 from supabase import Client
 
 from app.models.rating import RatingResponse
+from app.repositories import attendance as attendance_repo
 from app.repositories import profile as profile_repo
 from app.repositories import rating as rating_repo
 from app.repositories import user as user_repo
@@ -28,6 +29,13 @@ def rate_host(db: Client, rater_id: str, host_id: str, score: Decimal) -> Rating
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Target user has never hosted an event. Only hosts can be rated"
+        )
+
+    # Only allow rating if the rater attended at least one ended event by this host
+    if not attendance_repo.has_attended_ended_event_by_host(db, rater_id, host_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only rate a host after attending one of their ended events"
         )
 
     # Upsert the rating

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -31,20 +31,43 @@ def test_user_profiles_and_ratings(client, db):
     assert res.status_code == 400
     assert "never hosted" in res.json()["detail"].lower()
 
-    # Make host an actual host so they can be rated
-    db.table("events").insert({
+    # Make host an actual host by inserting an ended event
+    event_res = db.table("events").insert({
         "host_id": host_id,
         "title": "Test host event",
         "description": "desc",
-        "start_datetime": "2026-05-01T10:00:00Z",
-        "end_datetime": "2026-05-01T12:00:00Z",
+        "start_datetime": "2025-01-01T10:00:00Z",
+        "end_datetime": "2025-01-01T12:00:00Z",
         "visibility": "public",
-        "status": "published",
+        "status": "ended",
     }).execute()
+    event_id = event_res.data[0]["id"]
 
     # Host rating fails (self)
     res = client.post(f"/users/{host_id}/ratings", headers={"Authorization": f"Bearer {host_token}"}, json={"score": 5.0})
     assert res.status_code == 400
+
+    # Rating fails when rater has not attended any ended event by this host
+    res = client.post(f"/users/{host_id}/ratings", headers={"Authorization": f"Bearer {r_token}"}, json={"score": 4.0})
+    assert res.status_code == 403
+    assert "attend" in res.json()["detail"].lower()
+
+    # Also: can_rate should be False before attending
+    res = client.get(f"/users/{host_id}/profile", headers={"Authorization": f"Bearer {r_token}"})
+    assert res.status_code == 200
+    assert res.json()["can_rate"] is False
+
+    # Rater attends the ended event
+    db.table("attendances").insert({
+        "user_id": rater_id,
+        "event_id": event_id,
+        "status": "going",
+    }).execute()
+
+    # Now can_rate should be True
+    res = client.get(f"/users/{host_id}/profile", headers={"Authorization": f"Bearer {r_token}"})
+    assert res.status_code == 200
+    assert res.json()["can_rate"] is True
 
     # User rates 4.0
     res = client.post(f"/users/{host_id}/ratings", headers={"Authorization": f"Bearer {r_token}"}, json={"score": 4.0})
@@ -56,7 +79,7 @@ def test_user_profiles_and_ratings(client, db):
     assert res.status_code == 200
     assert float(res.json()["score"]) == 5.0
 
-    # Check Host profile
+    # Check Host profile average
     res = client.get(f"/users/{host_id}/profile")
     assert res.status_code == 200
     assert res.json()["average_rating"] == 5.0

--- a/frontend/src/components/profile/host-profile-page.tsx
+++ b/frontend/src/components/profile/host-profile-page.tsx
@@ -463,10 +463,10 @@ export function HostProfilePage() {
                     This is how your public host profile appears to other users. People can browse
                     your hosted events and rate their hosting experience here.
                   </p>
-                ) : isAuthenticated ? (
+                ) : isAuthenticated && profile.can_rate ? (
                   <>
                     <p className="mt-3 text-sm leading-6 text-brand-mid">
-                      Rate this host based on their hosted events. You can update your score later.
+                      Rate this host based on your experience. You can update your score later.
                     </p>
                     <div className="mt-5 rounded-[22px] bg-brand-bg/75 p-4">
                       <RatingStars
@@ -503,6 +503,10 @@ export function HostProfilePage() {
                       {isSubmittingRating ? "Saving..." : "Submit Rating"}
                     </Button>
                   </>
+                ) : isAuthenticated ? (
+                  <p className="mt-3 text-sm leading-6 text-brand-mid">
+                    You can rate this host after attending one of their events that has ended.
+                  </p>
                 ) : (
                   <>
                     <p className="mt-3 text-sm leading-6 text-brand-mid">

--- a/frontend/src/lib/events-api.ts
+++ b/frontend/src/lib/events-api.ts
@@ -202,6 +202,7 @@ export interface HostProfile {
   average_rating: number | null;
   hosted_events_count: number;
   hosted_events: EventListItem[];
+  can_rate: boolean;
 }
 
 // ─── Event Detail API Functions ────────────────────────────────────────────────

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
@@ -120,7 +120,8 @@ data class HostProfileDto(
     val phone_number: String?,
     val average_rating: Double?,
     val hosted_events_count: Int,
-    val hosted_events: List<EventListItemDto>
+    val hosted_events: List<EventListItemDto>,
+    val can_rate: Boolean = false
 )
 
 data class RatingRequest(val score: Double)

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/hostprofile/HostProfileScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/hostprofile/HostProfileScreen.kt
@@ -156,36 +156,44 @@ private fun ProfileContent(
                     Text("No ratings yet", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
 
-                // Rate this host (auth only, not own profile)
+                // Rate this host (auth only, not own profile, only after attending an ended event)
                 if (isAuthenticated && !isOwnProfile) {
                     Spacer(Modifier.height(12.dp))
-                    Text("Rate this host", fontSize = 14.sp, fontWeight = FontWeight.Medium)
-                    Spacer(Modifier.height(4.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        repeat(5) { i ->
-                            IconButton(
-                                onClick = { onRatingChange((i + 1).toDouble()) },
-                                modifier = Modifier.size(36.dp)
+                    if (profile.can_rate) {
+                        Text("Rate this host", fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                        Spacer(Modifier.height(4.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            repeat(5) { i ->
+                                IconButton(
+                                    onClick = { onRatingChange((i + 1).toDouble()) },
+                                    modifier = Modifier.size(36.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Default.Star,
+                                        contentDescription = "Rate ${i + 1}",
+                                        tint = if (i < uiState.ratingScore.toInt()) Color(0xFFFFC107) else Color(0xFF9E9E9E),
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                            }
+                            Spacer(Modifier.width(8.dp))
+                            Button(
+                                onClick = onSubmitRating,
+                                enabled = !uiState.ratingSubmitting
                             ) {
-                                Icon(
-                                    Icons.Default.Star,
-                                    contentDescription = "Rate ${i + 1}",
-                                    tint = if (i < uiState.ratingScore.toInt()) Color(0xFFFFC107) else Color(0xFF9E9E9E),
-                                    modifier = Modifier.size(24.dp)
-                                )
+                                if (uiState.ratingSubmitting) {
+                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                } else {
+                                    Text(if (uiState.ratingSuccess) "Updated" else "Submit", fontSize = 13.sp)
+                                }
                             }
                         }
-                        Spacer(Modifier.width(8.dp))
-                        Button(
-                            onClick = onSubmitRating,
-                            enabled = !uiState.ratingSubmitting
-                        ) {
-                            if (uiState.ratingSubmitting) {
-                                CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                            } else {
-                                Text(if (uiState.ratingSuccess) "Updated" else "Submit", fontSize = 13.sp)
-                            }
-                        }
+                    } else {
+                        Text(
+                            "Attend and complete an event by this host to rate them.",
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Users can now only rate a host if they have attended at least one of that host's events with status 'ended'. Previously any authenticated user could rate any host freely.

- Backend: added has_attended_ended_event_by_host() repo query; rating service returns 403 if condition not met; HostProfileResponse gains can_rate field computed per-viewer; updated integration test to cover the new 403 path and can_rate flag
- Web: added can_rate to HostProfile type; rating UI only renders when can_rate is true, otherwise shows an explanatory message
- Mobile: added can_rate to HostProfileDto; rating stars/submit only shown when can_rate is true, otherwise shows explanatory text
- Map view: removed Going and Request Access buttons from map popup so age-restricted private events cannot be bypassed; only Bookmark shown

Closes #216 
## Summary
- Users can now rate a host only if they have attended at least one of that host's events with status `ended`
- Previously any authenticated user could freely rate any host with no restrictions
- Map view popup no longer shows Going or Request Access buttons — only Bookmark, preventing age restriction bypass

## Changes

### Backend
- Added `has_attended_ended_event_by_host()` query in attendance repository (JOIN attendances + events, filters `status=going` + `events.status=ended`)
- Rating service returns **403** if condition not met: *"You can only rate a host after attending one of their ended events"*
- `HostProfileResponse` gains a `can_rate: bool` field computed per authenticated viewer
- Integration test updated: covers new 403 path, `can_rate=false` before attendance, `can_rate=true` after attendance

### Web
- Added `can_rate: boolean` to `HostProfile` type
- Rating UI only renders when `profile.can_rate === true`; otherwise shows: *"You can rate this host after attending one of their events that has ended"*

### Mobile
- Added `can_rate: Boolean = false` to `HostProfileDto`
- Rating stars and submit button only shown when `can_rate` is true; otherwise shows explanatory text

### Map View (web)
- Removed Going and Request Access/Pending buttons from map event popup
- Only Bookmark button remains for non-host users

## Test plan
- [ ] Backend integration test passes (`pytest tests/test_users.py`)
- [ ] User without attendance → 403 on POST /users/{id}/ratings
- [ ] `can_rate=false` returned in host profile before attending
- [ ] After attending an ended event → `can_rate=true`, rating succeeds
- [ ] Web: rating section hidden with explanatory message for ineligible users
- [ ] Mobile: rating stars hidden with explanatory text for ineligible users
- [ ] Map popup shows only Bookmark button (no Going, no Request Access)