### PR TITLE
Migrate CD pipeline from AWS EC2 to Azure Container Apps

### DIFF
--- a/.github/workflows/deploy-ec2-backup.yml.bak
+++ b/.github/workflows/deploy-ec2-backup.yml.bak
@@ -1,0 +1,155 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "docker-compose.prod.yml"
+      - "deploy/**"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sem:latest
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          build-args: |
+            NEXT_PUBLIC_API_BASE_URL=${{ secrets.BACKEND_URL }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sem:frontend-latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare deployment bundle
+        run: |
+          mkdir -p .deploy/backend
+          cp docker-compose.prod.yml .deploy/docker-compose.prod.yml
+          cp deploy/nginx/ec2-public-ip.conf .deploy/ec2-public-ip.conf
+          cp deploy/nginx/ec2-https.conf .deploy/ec2-https.conf
+          cp deploy/ec2/redeploy.sh .deploy/redeploy.sh
+          cat > .deploy/backend/.env.production <<EOF
+          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
+          ENVIRONMENT=production
+          FRONTEND_URL=${{ secrets.FRONTEND_URL }}
+          BACKEND_URL=${{ secrets.BACKEND_URL }}
+          CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}
+          EOF
+          if [ -n "${{ secrets.GOOGLE_CLIENT_ID }}" ]; then echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.GOOGLE_CLIENT_SECRET }}" ]; then echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.GOOGLE_REDIRECT_URI }}" ]; then echo "GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.SMTP_HOST }}" ]; then echo "SMTP_HOST=${{ secrets.SMTP_HOST }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.SMTP_PORT }}" ]; then echo "SMTP_PORT=${{ secrets.SMTP_PORT }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.SMTP_USER }}" ]; then echo "SMTP_USER=${{ secrets.SMTP_USER }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.SMTP_PASSWORD }}" ]; then echo "SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.SMTP_FROM_EMAIL }}" ]; then echo "SMTP_FROM_EMAIL=${{ secrets.SMTP_FROM_EMAIL }}" >> .deploy/backend/.env.production; fi
+          if [ -n "${{ secrets.SMTP_FROM_NAME }}" ]; then echo "SMTP_FROM_NAME=${{ secrets.SMTP_FROM_NAME }}" >> .deploy/backend/.env.production; fi
+
+      - uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: ".deploy/*"
+          target: "/home/${{ secrets.EC2_USERNAME }}/sem-backend"
+          strip_components: 1
+
+      - uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            cd /home/${{ secrets.EC2_USERNAME }}/sem-backend
+            echo "${{ secrets.DOCKERHUB_TOKEN }}" | sudo docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            sudo mkdir -p /opt/sem-backend/backend
+            sudo cp docker-compose.prod.yml /opt/sem-backend/docker-compose.prod.yml
+            sudo cp backend/.env.production /opt/sem-backend/backend/.env.production
+            sudo cp redeploy.sh /opt/sem-backend/redeploy.sh
+            sudo chmod +x /opt/sem-backend/redeploy.sh
+            if sudo test -f /etc/letsencrypt/live/thesocialeventmapper.social/fullchain.pem; then
+              sudo cp ec2-https.conf /etc/nginx/sites-available/sem-backend
+            else
+              sudo cp ec2-public-ip.conf /etc/nginx/sites-available/sem-backend
+            fi
+            if [ ! -L /etc/nginx/sites-enabled/sem-backend ]; then
+              sudo ln -s /etc/nginx/sites-available/sem-backend /etc/nginx/sites-enabled/sem-backend
+            fi
+            sudo rm -f /etc/nginx/sites-enabled/default
+            sudo nginx -t
+            sudo systemctl reload nginx
+            sudo BACKEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:latest FRONTEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:frontend-latest docker compose -f /opt/sem-backend/docker-compose.prod.yml pull
+            sudo BACKEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:latest FRONTEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:frontend-latest docker compose -f /opt/sem-backend/docker-compose.prod.yml up -d
+            sleep 5
+            for i in $(seq 1 12); do
+              if curl --fail --silent http://127.0.0.1:8000/health; then
+                break
+              fi
+              if [ "$i" -eq 12 ]; then
+                exit 1
+              fi
+              sleep 5
+            done
+            for i in $(seq 1 12); do
+              if curl --fail --silent http://127.0.0.1:3000/login > /dev/null; then
+                break
+              fi
+              if [ "$i" -eq 12 ]; then
+                exit 1
+              fi
+              sleep 5
+            done
+            sudo docker image prune -f
+
+      - name: Verify public health endpoint
+        run: |
+          sleep 5
+          for i in $(seq 1 12); do
+            if curl --fail --silent ${{ secrets.BACKEND_URL }}/health; then
+              exit 0
+            fi
+            sleep 5
+          done
+          exit 1
+
+      - name: Verify public frontend endpoint
+        run: |
+          sleep 5
+          for i in $(seq 1 12); do
+            if curl --fail --silent ${{ secrets.FRONTEND_URL }}/login > /dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Production
+name: Deploy Production (Azure ACA)
 
 on:
   push:
@@ -7,149 +7,195 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
-      - "docker-compose.prod.yml"
-      - "deploy/**"
       - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
-jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+env:
+  RESOURCE_GROUP: sem-backend-rg
+  ACA_ENV: sem-backend-env
+  ACR_NAME: semgroup9acr
+  ACR_SERVER: semgroup9acr.azurecr.io
+  BACKEND_APP: sem-backend
+  FRONTEND_APP: sem-frontend
 
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Install containerapp extension
+        run: az extension add --name containerapp --upgrade --only-show-errors
+
       - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v3
+      - name: ACR Docker login
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.ACR_SERVER }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
 
-      - uses: docker/build-push-action@v6
+      # ── Backend: build + push + deploy ──────────────────────────────────────
+
+      - name: Build & push backend image
+        uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: ./backend/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sem:latest
+          tags: |
+            ${{ env.ACR_SERVER }}/sem-backend:${{ github.sha }}
+            ${{ env.ACR_SERVER }}/sem-backend:latest
 
-      - uses: docker/build-push-action@v6
+      - name: Deploy backend to ACA
+        id: backend
+        run: |
+          set -e
+          IMAGE="${{ env.ACR_SERVER }}/sem-backend:${{ github.sha }}"
+          if az containerapp show -n ${{ env.BACKEND_APP }} -g ${{ env.RESOURCE_GROUP }} >/dev/null 2>&1; then
+            echo "Backend app exists — updating image..."
+            az containerapp update \
+              -n ${{ env.BACKEND_APP }} \
+              -g ${{ env.RESOURCE_GROUP }} \
+              --image "$IMAGE" \
+              --output none
+          else
+            echo "Creating backend container app..."
+            az containerapp create \
+              -n ${{ env.BACKEND_APP }} \
+              -g ${{ env.RESOURCE_GROUP }} \
+              --environment ${{ env.ACA_ENV }} \
+              --image "$IMAGE" \
+              --registry-server ${{ env.ACR_SERVER }} \
+              --registry-username "${{ secrets.ACR_USERNAME }}" \
+              --registry-password "${{ secrets.ACR_PASSWORD }}" \
+              --target-port 8000 \
+              --ingress external \
+              --min-replicas 0 \
+              --max-replicas 3 \
+              --cpu 0.5 \
+              --memory 1.0Gi \
+              --secrets \
+                supabase-url="${{ secrets.SUPABASE_URL }}" \
+                supabase-key="${{ secrets.SUPABASE_KEY }}" \
+                jwt-secret="${{ secrets.JWT_SECRET }}" \
+                google-client-id="${{ secrets.GOOGLE_CLIENT_ID }}" \
+                google-client-secret="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
+                google-redirect-uri="${{ secrets.GOOGLE_REDIRECT_URI }}" \
+                smtp-host="${{ secrets.SMTP_HOST }}" \
+                smtp-port="${{ secrets.SMTP_PORT }}" \
+                smtp-user="${{ secrets.SMTP_USER }}" \
+                smtp-password="${{ secrets.SMTP_PASSWORD }}" \
+                smtp-from-email="${{ secrets.SMTP_FROM_EMAIL }}" \
+                smtp-from-name="${{ secrets.SMTP_FROM_NAME }}" \
+              --env-vars \
+                "SUPABASE_URL=secretref:supabase-url" \
+                "SUPABASE_KEY=secretref:supabase-key" \
+                "JWT_SECRET=secretref:jwt-secret" \
+                "ENVIRONMENT=production" \
+                "FRONTEND_URL=${{ secrets.FRONTEND_URL }}" \
+                "BACKEND_URL=${{ secrets.BACKEND_URL }}" \
+                "CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}" \
+                "GOOGLE_CLIENT_ID=secretref:google-client-id" \
+                "GOOGLE_CLIENT_SECRET=secretref:google-client-secret" \
+                "GOOGLE_REDIRECT_URI=secretref:google-redirect-uri" \
+                "SMTP_HOST=secretref:smtp-host" \
+                "SMTP_PORT=secretref:smtp-port" \
+                "SMTP_USER=secretref:smtp-user" \
+                "SMTP_PASSWORD=secretref:smtp-password" \
+                "SMTP_FROM_EMAIL=secretref:smtp-from-email" \
+                "SMTP_FROM_NAME=secretref:smtp-from-name" \
+              --output none
+          fi
+
+          BACKEND_FQDN=$(az containerapp show -n ${{ env.BACKEND_APP }} -g ${{ env.RESOURCE_GROUP }} --query properties.configuration.ingress.fqdn -o tsv)
+          echo "backend_fqdn=$BACKEND_FQDN" >> $GITHUB_OUTPUT
+          echo "Backend URL: https://$BACKEND_FQDN"
+
+      - name: Backend health check
+        run: |
+          URL="https://${{ steps.backend.outputs.backend_fqdn }}/health"
+          for i in $(seq 1 20); do
+            if curl --fail --silent "$URL"; then
+              echo ""
+              echo "Backend healthy"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Backend health check failed"
+          exit 1
+
+      # ── Frontend: build + push + deploy ─────────────────────────────────────
+
+      - name: Build & push frontend image
+        uses: docker/build-push-action@v6
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
           push: true
           build-args: |
-            NEXT_PUBLIC_API_BASE_URL=${{ secrets.BACKEND_URL }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/sem:frontend-latest
+            NEXT_PUBLIC_API_BASE_URL=https://${{ steps.backend.outputs.backend_fqdn }}
+          tags: |
+            ${{ env.ACR_SERVER }}/sem-frontend:${{ github.sha }}
+            ${{ env.ACR_SERVER }}/sem-frontend:latest
 
-  deploy:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Prepare deployment bundle
+      - name: Deploy frontend to ACA
+        id: frontend
         run: |
-          mkdir -p .deploy/backend
-          cp docker-compose.prod.yml .deploy/docker-compose.prod.yml
-          cp deploy/nginx/ec2-public-ip.conf .deploy/ec2-public-ip.conf
-          cp deploy/nginx/ec2-https.conf .deploy/ec2-https.conf
-          cp deploy/ec2/redeploy.sh .deploy/redeploy.sh
-          cat > .deploy/backend/.env.production <<EOF
-          SUPABASE_URL=${{ secrets.SUPABASE_URL }}
-          SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}
-          JWT_SECRET=${{ secrets.JWT_SECRET }}
-          ENVIRONMENT=production
-          FRONTEND_URL=${{ secrets.FRONTEND_URL }}
-          BACKEND_URL=${{ secrets.BACKEND_URL }}
-          CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}
-          EOF
-          if [ -n "${{ secrets.GOOGLE_CLIENT_ID }}" ]; then echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.GOOGLE_CLIENT_SECRET }}" ]; then echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.GOOGLE_REDIRECT_URI }}" ]; then echo "GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.SMTP_HOST }}" ]; then echo "SMTP_HOST=${{ secrets.SMTP_HOST }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.SMTP_PORT }}" ]; then echo "SMTP_PORT=${{ secrets.SMTP_PORT }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.SMTP_USER }}" ]; then echo "SMTP_USER=${{ secrets.SMTP_USER }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.SMTP_PASSWORD }}" ]; then echo "SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.SMTP_FROM_EMAIL }}" ]; then echo "SMTP_FROM_EMAIL=${{ secrets.SMTP_FROM_EMAIL }}" >> .deploy/backend/.env.production; fi
-          if [ -n "${{ secrets.SMTP_FROM_NAME }}" ]; then echo "SMTP_FROM_NAME=${{ secrets.SMTP_FROM_NAME }}" >> .deploy/backend/.env.production; fi
+          set -e
+          IMAGE="${{ env.ACR_SERVER }}/sem-frontend:${{ github.sha }}"
+          if az containerapp show -n ${{ env.FRONTEND_APP }} -g ${{ env.RESOURCE_GROUP }} >/dev/null 2>&1; then
+            echo "Frontend app exists — updating image..."
+            az containerapp update \
+              -n ${{ env.FRONTEND_APP }} \
+              -g ${{ env.RESOURCE_GROUP }} \
+              --image "$IMAGE" \
+              --output none
+          else
+            echo "Creating frontend container app..."
+            az containerapp create \
+              -n ${{ env.FRONTEND_APP }} \
+              -g ${{ env.RESOURCE_GROUP }} \
+              --environment ${{ env.ACA_ENV }} \
+              --image "$IMAGE" \
+              --registry-server ${{ env.ACR_SERVER }} \
+              --registry-username "${{ secrets.ACR_USERNAME }}" \
+              --registry-password "${{ secrets.ACR_PASSWORD }}" \
+              --target-port 3000 \
+              --ingress external \
+              --min-replicas 0 \
+              --max-replicas 3 \
+              --cpu 0.5 \
+              --memory 1.0Gi \
+              --output none
+          fi
 
-      - uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: ".deploy/*"
-          target: "/home/${{ secrets.EC2_USERNAME }}/sem-backend"
-          strip_components: 1
+          FRONTEND_FQDN=$(az containerapp show -n ${{ env.FRONTEND_APP }} -g ${{ env.RESOURCE_GROUP }} --query properties.configuration.ingress.fqdn -o tsv)
+          echo "frontend_fqdn=$FRONTEND_FQDN" >> $GITHUB_OUTPUT
+          echo "Frontend URL: https://$FRONTEND_FQDN"
 
-      - uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            set -e
-            cd /home/${{ secrets.EC2_USERNAME }}/sem-backend
-            echo "${{ secrets.DOCKERHUB_TOKEN }}" | sudo docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-            sudo mkdir -p /opt/sem-backend/backend
-            sudo cp docker-compose.prod.yml /opt/sem-backend/docker-compose.prod.yml
-            sudo cp backend/.env.production /opt/sem-backend/backend/.env.production
-            sudo cp redeploy.sh /opt/sem-backend/redeploy.sh
-            sudo chmod +x /opt/sem-backend/redeploy.sh
-            if sudo test -f /etc/letsencrypt/live/thesocialeventmapper.social/fullchain.pem; then
-              sudo cp ec2-https.conf /etc/nginx/sites-available/sem-backend
-            else
-              sudo cp ec2-public-ip.conf /etc/nginx/sites-available/sem-backend
-            fi
-            if [ ! -L /etc/nginx/sites-enabled/sem-backend ]; then
-              sudo ln -s /etc/nginx/sites-available/sem-backend /etc/nginx/sites-enabled/sem-backend
-            fi
-            sudo rm -f /etc/nginx/sites-enabled/default
-            sudo nginx -t
-            sudo systemctl reload nginx
-            sudo BACKEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:latest FRONTEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:frontend-latest docker compose -f /opt/sem-backend/docker-compose.prod.yml pull
-            sudo BACKEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:latest FRONTEND_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/sem:frontend-latest docker compose -f /opt/sem-backend/docker-compose.prod.yml up -d
-            sleep 5
-            for i in $(seq 1 12); do
-              if curl --fail --silent http://127.0.0.1:8000/health; then
-                break
-              fi
-              if [ "$i" -eq 12 ]; then
-                exit 1
-              fi
-              sleep 5
-            done
-            for i in $(seq 1 12); do
-              if curl --fail --silent http://127.0.0.1:3000/login > /dev/null; then
-                break
-              fi
-              if [ "$i" -eq 12 ]; then
-                exit 1
-              fi
-              sleep 5
-            done
-            sudo docker image prune -f
-
-      - name: Verify public health endpoint
+      - name: Frontend health check
         run: |
-          sleep 5
-          for i in $(seq 1 12); do
-            if curl --fail --silent ${{ secrets.BACKEND_URL }}/health; then
+          URL="https://${{ steps.frontend.outputs.frontend_fqdn }}/login"
+          for i in $(seq 1 20); do
+            if curl --fail --silent "$URL" > /dev/null; then
+              echo "Frontend healthy"
               exit 0
             fi
-            sleep 5
+            sleep 10
           done
+          echo "Frontend health check failed"
           exit 1
 
-      - name: Verify public frontend endpoint
+      - name: Deployment summary
         run: |
-          sleep 5
-          for i in $(seq 1 12); do
-            if curl --fail --silent ${{ secrets.FRONTEND_URL }}/login > /dev/null; then
-              exit 0
-            fi
-            sleep 5
-          done
-          exit 1
+          echo "### Deployment URLs" >> $GITHUB_STEP_SUMMARY
+          echo "- Backend: https://${{ steps.backend.outputs.backend_fqdn }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Frontend: https://${{ steps.frontend.outputs.frontend_fqdn }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Replaces the EC2 SSH + docker-compose deploy flow with Azure Container Apps. Backend and frontend now build to Azure Container Registry and deploy as separate container apps with auto-HTTPS and scale-to-zero.

## Infrastructure (already provisioned in Azure)
- **Resource group:** `sem-backend-rg` (Germany West Central / Frankfurt)
- **ACA environment:** `sem-backend-env` (Consumption plan)
- **Container registry:** `semgroup9acr.azurecr.io` (Basic tier)

## Required GitHub Secrets (already set)
Added:
- `AZURE_CREDENTIALS` — service principal JSON
- `ACR_USERNAME`, `ACR_PASSWORD` — registry credentials

Removed (no longer referenced):
- `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
- `EC2_HOST`, `EC2_USERNAME`, `EC2_SSH_KEY`

## What happens on merge
1. Backend image built + pushed to ACR
2. Container app `sem-backend` created (first run) with all app secrets
3. Backend FQDN captured and passed as `NEXT_PUBLIC_API_BASE_URL` to frontend build
4. Frontend image built + pushed to ACR
5. Container app `sem-frontend` created
6. Health checks on both FQDNs

AWS EC2 instance remains up — DNS will be flipped after successful ACA deploy. Rollback: restore `deploy-ec2-backup.yml.bak` as `deploy.yml`.

Closes #225 