### PR TITLE
ci(deploy): sync ACA secrets from GitHub Secrets on each backend update

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,7 +113,25 @@ jobs:
           set -e
           IMAGE="${{ env.ACR_SERVER }}/sem-backend:${{ github.sha }}"
           if az containerapp show -n ${{ env.BACKEND_APP }} -g ${{ env.RESOURCE_GROUP }} >/dev/null 2>&1; then
-            echo "Backend app exists — updating image..."
+            echo "Backend app exists — syncing secrets from GitHub Secrets..."
+            az containerapp secret set \
+              -n ${{ env.BACKEND_APP }} \
+              -g ${{ env.RESOURCE_GROUP }} \
+              --secrets \
+                supabase-url="${{ secrets.SUPABASE_URL }}" \
+                supabase-key="${{ secrets.SUPABASE_KEY }}" \
+                jwt-secret="${{ secrets.JWT_SECRET }}" \
+                google-client-id="${{ secrets.GOOGLE_CLIENT_ID }}" \
+                google-client-secret="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
+                google-redirect-uri="${{ secrets.GOOGLE_REDIRECT_URI }}" \
+                smtp-host="${{ secrets.SMTP_HOST }}" \
+                smtp-port="${{ secrets.SMTP_PORT }}" \
+                smtp-user="${{ secrets.SMTP_USER }}" \
+                smtp-password="${{ secrets.SMTP_PASSWORD }}" \
+                smtp-from-email="${{ secrets.SMTP_FROM_EMAIL }}" \
+                smtp-from-name="${{ secrets.SMTP_FROM_NAME }}" \
+              --output none
+            echo "Updating image..."
             az containerapp update \
               -n ${{ env.BACKEND_APP }} \
               -g ${{ env.RESOURCE_GROUP }} \


### PR DESCRIPTION
## Summary

This PR is the final step of migrating our Supabase project from **South Korea** to **Frankfurt** (response times from the Korean region were consistently slow for our users in Europe/Turkey). The data migration itself was done out-of-band; this PR fixes the CD pipeline so that the rotated Supabase credentials actually reach the running backend.

### What was done outside this PR

- Created a new Supabase project in the Frankfurt region.
- Migrated the `public` schema and all data from the old project to the new one using `pg_dump -Fc` + `pg_restore` (via the Session Pooler, since Direct connection is IPv6-only). All 20 tables verified with matching row counts on both sides.
- Migrated the `event-images` storage bucket (281 objects) by listing + downloading from the old project and uploading to the new one via the Supabase Storage REST API (`/storage/v1/object/list/...` and `/storage/v1/object/{bucket}/{path}`), preserving paths and content types with `x-upsert: true`.
- Updated `SUPABASE_URL` and `SUPABASE_KEY` in GitHub repository secrets to point at the new Frankfurt project.

### Why this PR is needed

Updating the GitHub Secrets alone did **not** propagate to production. The existing `deploy.yml` only applies `--secrets` on the initial `az containerapp create` path. Once the backend Container App exists, subsequent deploys fall through to `az containerapp update --image`, which does not reconcile ACA secrets with GitHub Secrets. So the backend kept using the old Korean Supabase URL/key baked in at creation time, even after the secrets were rotated and new commits were deployed.

This isn't only a Supabase-migration problem — it silently affects every secret we rotate (`JWT_SECRET`, Google OAuth, SMTP, etc.).

### Change

- Add an `az containerapp secret set` step to the "app exists" branch of `deploy-backend`, running **before** the image update.
- The step pushes all backend secrets (`supabase-*`, `jwt-*`, `google-*`, `smtp-*`) from GitHub Secrets into ACA on every deploy.
- The following `az containerapp update --image` then starts a new revision that picks up the refreshed secrets.
- Net effect: GitHub Secrets become the single source of truth for backend production config. Rotating a secret + pushing to `main` (or re-running the workflow manually) is now sufficient to propagate it — no manual `az` commands required.

## Test plan

- [ ] Merge to `main` and watch the `Deploy Production (Azure ACA)` workflow — `deploy-backend` should show the new "syncing secrets from GitHub Secrets" step succeed.
- [ ] Backend health check step in the workflow returns 200 on `https://api.thesocialeventmapper.social/health`.
- [ ] Manual smoke test against production:
  - [ ] Log in on the web app.
  - [ ] Events list loads (validates the Frankfurt Postgres).
  - [ ] Open an event with an image and confirm the image renders (validates the migrated `event-images` storage bucket).
- [ ] After a few days of stable production traffic on the Frankfurt project, pause/delete the old South Korea Supabase project.



Closes #226 