### PR TITLE
Set refresh-token cookie on parent domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,6 +156,7 @@ jobs:
                 "FRONTEND_URL=${{ secrets.FRONTEND_URL }}" \
                 "BACKEND_URL=${{ secrets.BACKEND_URL }}" \
                 "CORS_ORIGINS=${{ secrets.CORS_ORIGINS }}" \
+                "COOKIE_DOMAIN=.thesocialeventmapper.social" \
                 "GOOGLE_CLIENT_ID=secretref:google-client-id" \
                 "GOOGLE_CLIENT_SECRET=secretref:google-client-secret" \
                 "GOOGLE_REDIRECT_URI=secretref:google-redirect-uri" \

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,6 +29,11 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = "http://localhost:3000"
     BACKEND_URL: str = "http://localhost:8888"
     CORS_ORIGINS: str = "http://localhost:3000"
+    # Cookie domain: when frontend and backend are on different subdomains of the same parent
+    # domain (e.g. thesocialeventmapper.social and api.thesocialeventmapper.social), set this
+    # to the parent domain (e.g. ".thesocialeventmapper.social") so the refresh-token cookie
+    # is shared across both. Leave empty for host-only cookies (single-host deploys).
+    COOKIE_DOMAIN: str = ""
 
     @property
     def is_production(self) -> bool:

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -50,7 +50,7 @@ REFRESH_COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 30 days
 
 
 def _set_refresh_cookie(response: Response, token: str) -> None:
-    response.set_cookie(
+    kwargs: dict = dict(
         key=REFRESH_TOKEN_COOKIE,
         value=token,
         httponly=True,
@@ -59,10 +59,16 @@ def _set_refresh_cookie(response: Response, token: str) -> None:
         max_age=REFRESH_COOKIE_MAX_AGE,
         path="/",
     )
+    if settings.COOKIE_DOMAIN:
+        kwargs["domain"] = settings.COOKIE_DOMAIN
+    response.set_cookie(**kwargs)
 
 
 def _clear_refresh_cookie(response: Response) -> None:
-    response.delete_cookie(key=REFRESH_TOKEN_COOKIE, path="/")
+    kwargs: dict = dict(key=REFRESH_TOKEN_COOKIE, path="/")
+    if settings.COOKIE_DOMAIN:
+        kwargs["domain"] = settings.COOKIE_DOMAIN
+    response.delete_cookie(**kwargs)
 
 
 def _user_response(user: dict) -> UserResponse:


### PR DESCRIPTION
Fix for cross-subdomain auth (frontend on apex, backend on api.). Backend cookie was host-only, so /api/proxy/auth/refresh from the frontend host never carried it.

- New COOKIE_DOMAIN env var
- Pipeline injects '.thesocialeventmapper.social' on first deploy of backend
- Already added to running ACA backend manually so the change takes effect on next image deploy