### PR TITLE
feat:added-clickable-profile-buttons-on-mobile

### DIFF
--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/RetrofitProvider.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/RetrofitProvider.kt
@@ -11,7 +11,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitProvider {
 
-    const val BASE_URL = "https://thesocialeventmapper.social/"
+    const val BASE_URL = "https://api.thesocialeventmapper.social/"
     private const val REFRESH_COOKIE_NAME = "sem_refresh_token"
 
     // In-memory cookie store to capture refresh token cookie from Set-Cookie header

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
@@ -610,7 +610,8 @@ private fun FullDetailContent(
                     uiState = uiState,
                     onCreateInvite = { viewModel.createInvite() },
                     onApprove = { id -> viewModel.decideRequest(id, "approved") },
-                    onReject = { id -> viewModel.decideRequest(id, "rejected") }
+                    onReject = { id -> viewModel.decideRequest(id, "rejected") },
+                    onNavigateToProfile = onNavigateToHost
                 )
             }
 
@@ -631,7 +632,8 @@ private fun FullDetailContent(
                 onPost = { viewModel.postComment() },
                 onDelete = { viewModel.deleteComment(it) },
                 onLoadMore = { viewModel.loadMoreComments() },
-                onRetry = { viewModel.loadMoreComments() }
+                onRetry = { viewModel.loadMoreComments() },
+                onNavigateToProfile = onNavigateToHost
             )
 
             Spacer(Modifier.height(32.dp))
@@ -659,7 +661,8 @@ private fun CommentSection(
     onPost: () -> Unit,
     onDelete: (String) -> Unit,
     onLoadMore: () -> Unit,
-    onRetry: () -> Unit
+    onRetry: () -> Unit,
+    onNavigateToProfile: (String) -> Unit
 ) {
     SectionHeader("Comments")
 
@@ -708,7 +711,8 @@ private fun CommentSection(
                 onDelete = { onDelete(comment.id) },
                 currentUserId = currentUserId,
                 hostId = hostId,
-                onDeleteReply = { onDelete(it) }
+                onDeleteReply = { onDelete(it) },
+                onNavigateToProfile = onNavigateToProfile
             )
             Spacer(Modifier.height(8.dp))
         }
@@ -732,7 +736,8 @@ private fun CommentItem(
     onDelete: () -> Unit,
     currentUserId: String? = null,
     hostId: String? = null,
-    onDeleteReply: (String) -> Unit = {}
+    onDeleteReply: (String) -> Unit = {},
+    onNavigateToProfile: (String) -> Unit = {}
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -744,7 +749,13 @@ private fun CommentItem(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(comment.user.username, fontWeight = FontWeight.SemiBold, fontSize = 13.sp)
+                Text(
+                    comment.user.username,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { onNavigateToProfile(comment.user.id) }
+                )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         formatCommentTime(comment.created_at),
@@ -776,7 +787,13 @@ private fun CommentItem(
                                     horizontalArrangement = Arrangement.SpaceBetween,
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Text(reply.user.username, fontWeight = FontWeight.SemiBold, fontSize = 12.sp)
+                                    Text(
+                                        reply.user.username,
+                                        fontWeight = FontWeight.SemiBold,
+                                        fontSize = 12.sp,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.clickable { onNavigateToProfile(reply.user.id) }
+                                    )
                                     Row(verticalAlignment = Alignment.CenterVertically) {
                                         Text(
                                             formatCommentTime(reply.created_at),
@@ -869,7 +886,8 @@ private fun ManageInvitesSection(
     uiState: EventDetailUiState,
     onCreateInvite: () -> Unit,
     onApprove: (String) -> Unit,
-    onReject: (String) -> Unit
+    onReject: (String) -> Unit,
+    onNavigateToProfile: (String) -> Unit
 ) {
     val clipboard = LocalClipboardManager.current
 
@@ -968,7 +986,8 @@ private fun ManageInvitesSection(
             AccessRequestRow(
                 request = req,
                 onApprove = { onApprove(req.id) },
-                onReject = { onReject(req.id) }
+                onReject = { onReject(req.id) },
+                onNavigateToProfile = onNavigateToProfile
             )
             Spacer(Modifier.height(4.dp))
         }
@@ -986,7 +1005,8 @@ private fun ManageInvitesSection(
 private fun AccessRequestRow(
     request: AccessRequestResponseDto,
     onApprove: () -> Unit,
-    onReject: () -> Unit
+    onReject: () -> Unit,
+    onNavigateToProfile: (String) -> Unit = {}
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -1003,7 +1023,10 @@ private fun AccessRequestRow(
                 request.username,
                 fontWeight = FontWeight.Medium,
                 fontSize = 14.sp,
-                modifier = Modifier.weight(1f)
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { onNavigateToProfile(request.user_id) }
             )
             Spacer(Modifier.width(8.dp))
             // Approve button


### PR DESCRIPTION
## Summary

Two related mobile changes:

### 1. Clickable user identities on event detail (TA feedback from MVP demo)

During the MVP demo, one of the TAs pointed out that user names shown across the app are static text — there's no way to tap a name to view that user's profile. The web side will be addressed separately; this PR covers the mobile (Android/Compose) surfaces where a user identity is rendered:

- **Comment author (parent comments)** — tapping the username on a comment now navigates to that user's profile.
- **Comment author (replies)** — same behavior on reply rows under a parent comment.
- **Pending access request username** (visible to the host of a private event in the "Manage Invites" section) — tapping the requester's name navigates to their profile; the existing approve/reject icon buttons are unchanged.

Implementation: threaded the existing `onNavigateToHost` callback from `NavGraph` (which already routes to `Routes.hostProfile(userId)`) down through `EventDetailScreen` → `CommentSection`/`ManageInvitesSection` → `CommentItem`/`AccessRequestRow`. Clickable usernames are styled in the primary color so the affordance is visible.

Self-click handling needs no special case: `HostProfileScreen` already checks `currentUserId == userId` and renders the appropriate own-profile view (no rate button, etc.), so tapping your own name just lands you on your own profile.

**Out of scope on mobile:**
- Attendee list — not currently rendered on mobile event detail (only an attendee count is shown), so there's nothing to make clickable. Adding the list would be a feature add, not a wiring task.
- Rater list on host profile — not rendered, and the `GET /users/{id}/profile` endpoint only returns `average_rating`, not individual raters. No backend or UI change here.
- Notifications/profile screens — no usernames currently displayed.

**No backend changes:** verified that all the response payloads we needed already include the user id field (`comment.user.id`, `access_request.user_id`, `host_id`, `attendees[].id`).

### 2. Fix mobile API base URL after Azure Container Apps migration

Mobile was hitting `https://thesocialeventmapper.social/` for all API calls. This worked under the old AWS EC2 setup where nginx on the same host proxied `/api/*` to the backend, but after the migration to Azure Container Apps the backend lives at a separate subdomain (`https://api.thesocialeventmapper.social/`) and the root domain serves only the Next.js frontend. As a result the app was getting back the frontend's HTML 404 page on every request and crashing on the discovery screen with `404: <!DOCTYPE html>...`.

Updated `RetrofitProvider.BASE_URL` to point at the API subdomain.

## Test plan

- [ ] Open the app on a clean install — Discovery screen loads events instead of showing the HTML 404 dump.
- [ ] Open any event detail with comments → tap a commenter's username → host profile screen for that user opens.
- [ ] Reply to a comment → tap the reply author's username → profile screen opens.
- [ ] As host of a private event, with at least one pending access request: tap the requester's username → profile opens. Tap the ✓ / ✗ buttons → still approve/reject as before, do not navigate.
- [ ] Tap your own username on one of your own comments → lands on your own profile (own-profile view, no rate button).
- [ ] Regression: the "Host" button under the event detail still navigates to the host profile.

Closes #238, Closes #241