### PR TITLE
feat:advanced-discovery-filters

### DIFF
--- a/backend/app/repositories/event.py
+++ b/backend/app/repositories/event.py
@@ -209,12 +209,18 @@ def get_valid_category_ids(db: Client, category_ids: list[str]) -> set[str]:
 
 # --- Discovery ---
 
+# Accessibility filter mapping: API canonical name → DB column.
+# `captions` deliberately maps to the existing `captions_support` column.
+# Sign-language interpretation is a separate accessibility feature; modelling
+# it as a column is a follow-up (would require a venue_metadata migration +
+# create-event UI). The previous `sign_language` API name was misleading
+# because it claimed support that the underlying column does not guarantee.
 _ACCESSIBILITY_COLS = (
     "wheelchair_access",
     "accessible_restroom",
     "elevator",
     "seating",
-    "sign_language",
+    "captions",
     "quiet_friendly",
 )
 _ACCESSIBILITY_DB_MAP = {
@@ -222,7 +228,7 @@ _ACCESSIBILITY_DB_MAP = {
     "accessible_restroom": "accessible_restroom",
     "elevator": "elevator_available",
     "seating": "seating_available",
-    "sign_language": "captions_support",
+    "captions": "captions_support",
     "quiet_friendly": "quiet_friendly",
 }
 

--- a/backend/app/repositories/event.py
+++ b/backend/app/repositories/event.py
@@ -209,20 +209,74 @@ def get_valid_category_ids(db: Client, category_ids: list[str]) -> set[str]:
 
 # --- Discovery ---
 
+_ACCESSIBILITY_COLS = (
+    "wheelchair_access",
+    "accessible_restroom",
+    "elevator",
+    "seating",
+    "sign_language",
+    "quiet_friendly",
+)
+_ACCESSIBILITY_DB_MAP = {
+    "wheelchair_access": "wheelchair_access",
+    "accessible_restroom": "accessible_restroom",
+    "elevator": "elevator_available",
+    "seating": "seating_available",
+    "sign_language": "captions_support",
+    "quiet_friendly": "quiet_friendly",
+}
+
+
+def _bounding_box(lat: float, lng: float, radius_km: float) -> tuple[float, float, float, float]:
+    """Return (lat_min, lat_max, lng_min, lng_max) for a degree-approximation bounding box."""
+    # 1 degree latitude ≈ 111.32 km. Longitude scales with cos(latitude).
+    import math
+
+    lat_delta = radius_km / 111.32
+    cos_lat = max(math.cos(math.radians(lat)), 0.01)
+    lng_delta = radius_km / (111.32 * cos_lat)
+    return lat - lat_delta, lat + lat_delta, lng - lng_delta, lng + lng_delta
+
+
+def _weekend_window(now: datetime) -> tuple[datetime, datetime]:
+    """Return (saturday_00:00, monday_00:00) for the upcoming weekend in UTC."""
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    # Monday=0 ... Saturday=5, Sunday=6
+    days_until_saturday = (5 - today_start.weekday()) % 7
+    saturday = today_start + timedelta(days=days_until_saturday)
+    monday = saturday + timedelta(days=2)
+    return saturday, monday
+
+
 def list_events(
     db: Client,
     *,
     search: str | None = None,
     category_id: str | None = None,
-    temporal_filter: str | None = None,
+    quick_filter: str | None = None,
+    start_after: datetime | None = None,
+    end_before: datetime | None = None,
+    near_lat: float | None = None,
+    near_lng: float | None = None,
+    radius_km: float | None = None,
+    accessibility: dict[str, bool | None] | None = None,
+    sort: str = "start_time",
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[dict], int]:
-    """Return (events, total_count) for all published/updated events (public + private)."""
-    now = datetime.now(UTC)
+    """Return (events, total_count) honouring all discovery filters.
 
-    # Resolve category event IDs upfront (shared by both count and data queries)
-    category_event_ids: list[str] | None = None
+    For sort in {"distance", "category"} the repo returns the FULL filtered
+    candidate set (without DB-side pagination) so the service can sort by a
+    Python-computed key and slice. For sort="start_time" pagination happens
+    at the database for cheaper reads.
+    """
+    now = datetime.now(UTC)
+    accessibility = accessibility or {}
+
+    # Whitelist event IDs from related tables ── intersected at the end.
+    whitelists: list[set[str]] = []
+
     if category_id:
         cat_result = (
             db.table("event_categories")
@@ -230,44 +284,111 @@ def list_events(
             .eq("category_id", category_id)
             .execute()
         )
-        category_event_ids = [row["event_id"] for row in (cat_result.data or [])]
-        if not category_event_ids:
+        ids = {row["event_id"] for row in (cat_result.data or [])}
+        if not ids:
             return [], 0
+        whitelists.append(ids)
+
+    accessibility_required = {k: v for k, v in accessibility.items() if v is True}
+    if accessibility_required:
+        venue_q = db.table("venue_metadata").select("event_id")
+        for canonical, db_col in _ACCESSIBILITY_DB_MAP.items():
+            if accessibility_required.get(canonical):
+                venue_q = venue_q.eq(db_col, True)
+        venue_result = venue_q.execute()
+        ids = {row["event_id"] for row in (venue_result.data or [])}
+        if not ids:
+            return [], 0
+        whitelists.append(ids)
+
+    if near_lat is not None and near_lng is not None and radius_km is not None:
+        lat_min, lat_max, lng_min, lng_max = _bounding_box(near_lat, near_lng, radius_km)
+        loc_result = (
+            db.table("event_locations")
+            .select("event_id")
+            .eq("is_primary", True)
+            .gte("latitude", lat_min)
+            .lte("latitude", lat_max)
+            .gte("longitude", lng_min)
+            .lte("longitude", lng_max)
+            .execute()
+        )
+        ids = {row["event_id"] for row in (loc_result.data or [])}
+        if not ids:
+            return [], 0
+        whitelists.append(ids)
+
+    final_whitelist: list[str] | None = None
+    if whitelists:
+        intersection = set.intersection(*whitelists)
+        if not intersection:
+            return [], 0
+        final_whitelist = list(intersection)
+
+    is_past = quick_filter == "past"
 
     def _apply_filters(q):
-        q = q.in_("status", ["published", "updated"])
-        q = q.gte("end_datetime", now.isoformat())  # Exclude events whose end time has passed
+        if is_past:
+            q = q.in_("status", ["ended", "cancelled", "updated", "published"])
+            q = q.lt("end_datetime", now.isoformat())
+        else:
+            q = q.in_("status", ["published", "updated"])
+            q = q.gte("end_datetime", now.isoformat())
+
         if search:
             safe = search.replace("%", r"\%").replace("_", r"\_")
             q = q.or_(f"title.ilike.%{safe}%,description.ilike.%{safe}%")
-        if category_event_ids is not None:
-            q = q.in_("id", category_event_ids)
-        if temporal_filter == "upcoming":
-            q = q.gte("start_datetime", now.isoformat())
-        elif temporal_filter == "today":
+        if final_whitelist is not None:
+            q = q.in_("id", final_whitelist)
+
+        if quick_filter == "now":
+            q = q.lte("start_datetime", now.isoformat()).gte("end_datetime", now.isoformat())
+        elif quick_filter == "today":
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
             tomorrow = today_start + timedelta(days=1)
             q = q.gte("start_datetime", today_start.isoformat()).lt("start_datetime", tomorrow.isoformat())
-        elif temporal_filter == "this_week":
+        elif quick_filter == "this_week":
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
             week_end = today_start + timedelta(days=7)
             q = q.gte("start_datetime", today_start.isoformat()).lt("start_datetime", week_end.isoformat())
+        elif quick_filter == "weekend":
+            sat, mon = _weekend_window(now)
+            q = q.gte("start_datetime", sat.isoformat()).lt("start_datetime", mon.isoformat())
+        elif quick_filter == "upcoming":
+            q = q.gte("start_datetime", now.isoformat())
+
+        if start_after is not None:
+            q = q.gte("start_datetime", start_after.isoformat())
+        if end_before is not None:
+            q = q.lte("end_datetime", end_before.isoformat())
+
         return q
 
-    # Count query: fetch only IDs to avoid transferring all columns just for counting
     count_result = _apply_filters(db.table("events").select("id", count="exact")).execute()
     total = count_result.count or 0
+    if total == 0:
+        return [], 0
 
-    offset = (page - 1) * page_size
-    if offset >= total:
-        return [], total
+    if sort == "start_time":
+        offset = (page - 1) * page_size
+        if offset >= total:
+            return [], total
+        order_desc = is_past  # past events: most recent first
+        result = (
+            _apply_filters(db.table("events").select(_EVENT_COLS))
+            .order("start_datetime", desc=order_desc)
+            .order("id")
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        return result.data or [], total
 
-    # Data query: fetch full rows, sorted deterministically
+    # Distance / category sort: fetch full candidate set so the service layer
+    # can sort by a Python-computed key and slice for pagination.
     result = (
         _apply_filters(db.table("events").select(_EVENT_COLS))
         .order("start_datetime")
         .order("id")
-        .range(offset, offset + page_size - 1)
         .execute()
     )
     return result.data or [], total

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,5 +1,6 @@
 """Event endpoints — HTTP layer only."""
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, UploadFile, status
@@ -64,22 +65,103 @@ def _optional_user_id(authorization: str | None = Header(default=None)) -> str |
         ) from e
 
 
-@router.get("", response_model=EventListResponse)
+@router.get(
+    "",
+    response_model=EventListResponse,
+    summary="Discover events",
+    description=(
+        "Paginated event discovery with quick filters, custom time window, accessibility "
+        "filters, distance bounding box, and ranking by start time / distance / category. "
+        "When the client opts in via use_default_area, the authenticated user's stored "
+        "default location is used in place of explicit near_lat/near_lng."
+    ),
+)
 def list_events_endpoint(
     search: str | None = Query(default=None, max_length=200),
     category_id: UUID | None = Query(default=None),
-    temporal_filter: str | None = Query(default=None, pattern="^(upcoming|today|this_week)$"),
+    quick_filter: str | None = Query(
+        default=None,
+        pattern="^(now|today|weekend|upcoming|this_week|past)$",
+        description="Time-window quick filter. Mutually exclusive with start_after/end_before.",
+    ),
+    start_after: datetime | None = Query(
+        default=None,
+        description="Custom window: only events starting at or after this time.",
+    ),
+    end_before: datetime | None = Query(
+        default=None,
+        description="Custom window: only events ending at or before this time.",
+    ),
+    near_lat: float | None = Query(default=None, ge=-90, le=90),
+    near_lng: float | None = Query(default=None, ge=-180, le=180),
+    radius_km: float | None = Query(default=None, gt=0, le=500),
+    use_default_area: bool = Query(
+        default=False,
+        description="If true, use the authenticated user's stored default area. Ignored when near_lat/near_lng are provided.",
+    ),
+    wheelchair: bool | None = Query(default=None),
+    accessible_restroom: bool | None = Query(default=None),
+    elevator: bool | None = Query(default=None),
+    seating: bool | None = Query(default=None),
+    sign_language: bool | None = Query(default=None),
+    quiet_friendly: bool | None = Query(default=None),
+    sort: str | None = Query(
+        default=None,
+        pattern="^(start_time|distance|category)$",
+        description="Sort order. Defaults to distance when location is provided, otherwise start_time.",
+    ),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     user_id: str | None = Depends(_optional_user_id),
 ):
+    if quick_filter is not None and (start_after is not None or end_before is not None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="quick_filter cannot be combined with start_after/end_before",
+        )
+    if start_after is not None and end_before is not None and start_after >= end_before:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="start_after must be earlier than end_before",
+        )
+    if (near_lat is None) != (near_lng is None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="near_lat and near_lng must be provided together",
+        )
+    if radius_km is not None and near_lat is None and not use_default_area:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="radius_km requires near_lat/near_lng or use_default_area",
+        )
+    if use_default_area and user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="use_default_area requires authentication",
+        )
+
     db = get_supabase()
     return list_events_svc(
         db,
         user_id=user_id,
         search=search,
         category_id=str(category_id) if category_id else None,
-        temporal_filter=temporal_filter,
+        quick_filter=quick_filter,
+        start_after=start_after,
+        end_before=end_before,
+        near_lat=near_lat,
+        near_lng=near_lng,
+        radius_km=radius_km,
+        use_default_area=use_default_area,
+        accessibility={
+            "wheelchair_access": wheelchair,
+            "accessible_restroom": accessible_restroom,
+            "elevator": elevator,
+            "seating": seating,
+            "sign_language": sign_language,
+            "quiet_friendly": quiet_friendly,
+        },
+        sort=sort,
         page=page,
         page_size=page_size,
     )

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -103,12 +103,24 @@ def list_events_endpoint(
     accessible_restroom: bool | None = Query(default=None),
     elevator: bool | None = Query(default=None),
     seating: bool | None = Query(default=None),
-    sign_language: bool | None = Query(default=None),
+    captions: bool | None = Query(
+        default=None,
+        description=(
+            "Filter events whose venue offers captions support. "
+            "Note: this maps to the existing `captions_support` venue column; a "
+            "dedicated sign-language interpretation column is not modelled yet."
+        ),
+    ),
     quiet_friendly: bool | None = Query(default=None),
     sort: str | None = Query(
         default=None,
         pattern="^(start_time|distance|category)$",
-        description="Sort order. Defaults to distance when location is provided, otherwise start_time.",
+        description=(
+            "Sort order. Defaults to distance when location is provided, otherwise start_time. "
+            "sort=distance requires a location (near_lat/near_lng or use_default_area). "
+            "sort=category requires a narrowing filter — search, category_id, quick_filter, "
+            "custom window, accessibility, or location — to keep the in-memory candidate set bounded."
+        ),
     ),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
@@ -158,7 +170,7 @@ def list_events_endpoint(
             "accessible_restroom": accessible_restroom,
             "elevator": elevator,
             "seating": seating,
-            "sign_language": sign_language,
+            "captions": captions,
             "quiet_friendly": quiet_friendly,
         },
         sort=sort,

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -627,6 +627,36 @@ def list_events(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="sort=distance requires near_lat/near_lng or use_default_area",
         )
+    # sort=category fetches the full filtered candidate set into memory and
+    # ranks in Python (PostgREST cannot order by an aggregated joined column
+    # in a single round-trip). To keep memory bounded on large datasets, we
+    # require the request to narrow the candidate set first — same shape of
+    # constraint as sort=distance requiring a location.
+    if sort == "category":
+        accessibility_active = any(
+            v is True for v in (accessibility or {}).values()
+        )
+        has_search = bool(search and search.strip())
+        has_window = (
+            quick_filter is not None
+            or start_after is not None
+            or end_before is not None
+        )
+        if not (
+            has_search
+            or category_id is not None
+            or has_window
+            or accessibility_active
+            or has_location
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "sort=category requires a narrowing filter: search, "
+                    "category_id, quick_filter, custom window, accessibility, "
+                    "or a location."
+                ),
+            )
     if sort is None:
         sort = "distance" if has_location else "start_time"
 

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -1,9 +1,20 @@
 """Event service — business logic, validation, orchestration."""
 
+import math
 from datetime import UTC, datetime, timedelta
 
 from fastapi import HTTPException, status
 from supabase import Client
+
+
+def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """Great-circle distance in kilometres between two (lat, lng) points."""
+    r = 6371.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lng2 - lng1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
 
 from app.models.event import (
     EventCreateRequest,
@@ -580,15 +591,58 @@ def list_events(
     user_id: str | None = None,
     search: str | None = None,
     category_id: str | None = None,
-    temporal_filter: str | None = None,
+    quick_filter: str | None = None,
+    start_after: datetime | None = None,
+    end_before: datetime | None = None,
+    near_lat: float | None = None,
+    near_lng: float | None = None,
+    radius_km: float | None = None,
+    use_default_area: bool = False,
+    accessibility: dict[str, bool | None] | None = None,
+    sort: str | None = None,
     page: int = 1,
     page_size: int = 20,
 ) -> EventListResponse:
+    # Resolve default-area fallback when client opts in and didn't pass coords.
+    if use_default_area and near_lat is None and near_lng is None and user_id:
+        result = (
+            db.table("users")
+            .select("default_location_lat,default_location_lng")
+            .eq("id", user_id)
+            .execute()
+        )
+        row = result.data[0] if result.data else {}
+        if row.get("default_location_lat") is None or row.get("default_location_lng") is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="No default area set on profile",
+            )
+        near_lat = row["default_location_lat"]
+        near_lng = row["default_location_lng"]
+
+    has_location = near_lat is not None and near_lng is not None
+    if sort == "distance" and not has_location:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="sort=distance requires near_lat/near_lng or use_default_area",
+        )
+    if sort is None:
+        sort = "distance" if has_location else "start_time"
+
+    effective_radius_km = radius_km if radius_km is not None else (50.0 if has_location else None)
+
     events, total = event_repo.list_events(
         db,
         search=search,
         category_id=category_id,
-        temporal_filter=temporal_filter,
+        quick_filter=quick_filter,
+        start_after=start_after,
+        end_before=end_before,
+        near_lat=near_lat,
+        near_lng=near_lng,
+        radius_km=effective_radius_km,
+        accessibility=accessibility or {},
+        sort=sort,
         page=page,
         page_size=page_size,
     )
@@ -596,6 +650,36 @@ def list_events(
     total_pages = (total + page_size - 1) // page_size if total > 0 else 0
     if not events:
         return EventListResponse(items=[], total=total, page=page, page_size=page_size, total_pages=total_pages)
+
+    # For sort in {distance, category} the repo returned the full filtered set;
+    # rank in Python and slice to the requested page.
+    if sort in ("distance", "category"):
+        if sort == "distance":
+            full_event_ids = [e["id"] for e in events]
+            locations_by_event = event_repo.get_primary_locations_for_events(db, full_event_ids)
+
+            def _distance_key(ev: dict) -> tuple[float, str]:
+                loc = locations_by_event.get(ev["id"])
+                if not loc or loc.get("latitude") is None or loc.get("longitude") is None:
+                    return (float("inf"), ev["id"])
+                return (_haversine_km(near_lat, near_lng, loc["latitude"], loc["longitude"]), ev["id"])
+
+            events.sort(key=_distance_key)
+        else:  # category
+            full_event_ids = [e["id"] for e in events]
+            categories_by_event_full = event_repo.get_categories_for_events(db, full_event_ids)
+
+            def _category_key(ev: dict) -> tuple[str, str, str]:
+                cats = categories_by_event_full.get(ev["id"]) or []
+                primary = min((c.get("name", "") for c in cats), default="￿")
+                return (primary, ev["start_datetime"], ev["id"])
+
+            events.sort(key=_category_key)
+
+        offset = (page - 1) * page_size
+        events = events[offset:offset + page_size]
+        if not events:
+            return EventListResponse(items=[], total=total, page=page, page_size=page_size, total_pages=total_pages)
 
     event_ids = [e["id"] for e in events]
     locations_by_event = event_repo.get_primary_locations_for_events(db, event_ids)

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -6,16 +6,6 @@ from datetime import UTC, datetime, timedelta
 from fastapi import HTTPException, status
 from supabase import Client
 
-
-def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
-    """Great-circle distance in kilometres between two (lat, lng) points."""
-    r = 6371.0
-    phi1, phi2 = math.radians(lat1), math.radians(lat2)
-    dphi = math.radians(lat2 - lat1)
-    dlam = math.radians(lng2 - lng1)
-    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
-    return 2 * r * math.asin(math.sqrt(a))
-
 from app.models.event import (
     EventCreateRequest,
     EventDetailResponse,
@@ -31,6 +21,17 @@ from app.repositories import image as image_repo
 from app.repositories import invite as invite_repo
 from app.repositories import user as user_repo
 from app.services.rate_limit import is_rate_limit_exempt_email
+
+
+def _haversine_km(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    """Great-circle distance in kilometres between two (lat, lng) points."""
+    r = 6371.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lng2 - lng1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
 
 # --- Validators ---
 

--- a/backend/app/services/profile.py
+++ b/backend/app/services/profile.py
@@ -26,6 +26,13 @@ def get_host_profile(db: Client, target_user_id: str, current_user_id: str | Non
     # Only include drafts if the current user is viewing their own profile
     is_owner = current_user_id == target_user_id
     events = profile_repo.get_hosted_events(db, target_user_id, include_drafts=is_owner)
+
+    # Order upcoming events first (asc by start) then past events (most recent ended first).
+    upcoming = [e for e in events if e.get("status") != "ended"]
+    past = [e for e in events if e.get("status") == "ended"]
+    upcoming.sort(key=lambda e: e["start_datetime"])
+    past.sort(key=lambda e: e["start_datetime"], reverse=True)
+    events = upcoming + past
     event_ids = [e["id"] for e in events]
 
     locations_by_event = event_repo.get_primary_locations_for_events(db, event_ids)

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -426,7 +426,7 @@ class TestListEventsTemporalFilter:
         cat_ids = _get_category_ids(1)
         future_event = _create_published_event(user["id"], cat_ids, title="Future Event", days_from_now=10)
 
-        resp = client.get("/events?temporal_filter=upcoming")
+        resp = client.get("/events?quick_filter=upcoming")
         assert resp.status_code == 200
         ids = [i["id"] for i in resp.json()["items"]]
         assert future_event["id"] in ids
@@ -435,7 +435,7 @@ class TestListEventsTemporalFilter:
         _cleanup_user(user["id"])
 
     def test_today_filter(self):
-        resp = client.get("/events?temporal_filter=today")
+        resp = client.get("/events?quick_filter=today")
         assert resp.status_code == 200
         data = resp.json()
         # All returned events must start today (UTC)
@@ -449,7 +449,7 @@ class TestListEventsTemporalFilter:
         cat_ids = _get_category_ids(1)
         event = _create_published_event(user["id"], cat_ids, title="This Week Event", days_from_now=3)
 
-        resp = client.get("/events?temporal_filter=this_week")
+        resp = client.get("/events?quick_filter=this_week")
         assert resp.status_code == 200
         data = resp.json()
         ids = [i["id"] for i in data["items"]]
@@ -463,7 +463,7 @@ class TestListEventsTemporalFilter:
         cat_ids = _get_category_ids(1)
         far_event = _create_published_event(user["id"], cat_ids, title="Far Future Event", days_from_now=30)
 
-        resp = client.get("/events?temporal_filter=this_week")
+        resp = client.get("/events?quick_filter=this_week")
         ids = [i["id"] for i in resp.json()["items"]]
         assert far_event["id"] not in ids
 
@@ -471,7 +471,7 @@ class TestListEventsTemporalFilter:
         _cleanup_user(user["id"])
 
     def test_invalid_temporal_filter_rejected(self):
-        resp = client.get("/events?temporal_filter=yesterday")
+        resp = client.get("/events?quick_filter=yesterday")
         assert resp.status_code == 422
 
 
@@ -571,7 +571,7 @@ class TestListEventsCombinedFilters:
         ev_near = _create_published_event(user["id"], cat_ids, title=f"SrchTmp{unique}", days_from_now=3)
         ev_far = _create_published_event(user["id"], cat_ids, title=f"SrchTmp{unique}", days_from_now=30)
 
-        resp = client.get(f"/events?search=SrchTmp{unique}&temporal_filter=this_week")
+        resp = client.get(f"/events?search=SrchTmp{unique}&quick_filter=this_week")
         ids = [i["id"] for i in resp.json()["items"]]
         assert ev_near["id"] in ids
         assert ev_far["id"] not in ids
@@ -592,7 +592,7 @@ class TestListEventsCombinedFilters:
         ev_wrong_cat = _create_published_event(user["id"], [cat_b], title=f"AllFilt{unique}", days_from_now=2)
         ev_far = _create_published_event(user["id"], [cat_a], title=f"AllFilt{unique}", days_from_now=20)
 
-        resp = client.get(f"/events?search=AllFilt{unique}&category_id={cat_a}&temporal_filter=this_week&page=1&page_size=10")
+        resp = client.get(f"/events?search=AllFilt{unique}&category_id={cat_a}&quick_filter=this_week&page=1&page_size=10")
         assert resp.status_code == 200
         ids = [i["id"] for i in resp.json()["items"]]
         assert ev_target["id"] in ids
@@ -601,4 +601,220 @@ class TestListEventsCombinedFilters:
 
         for e in (ev_target, ev_wrong_cat, ev_far):
             _cleanup_event(e["id"])
+        _cleanup_user(user["id"])
+
+
+class TestListEventsNewQuickFilters:
+    """Quick filters added in final-milestone discovery (now / past / weekend)."""
+
+    def test_past_filter_returns_ended_events(self):
+        """quick_filter=past returns events whose end_datetime has passed."""
+        user = _create_test_user("pastflt")
+        cat_ids = _get_category_ids(1)
+        # Direct DB insert to backdate end_datetime
+        from datetime import UTC, datetime, timedelta
+        result = db.table("events").insert({
+            "host_id": user["id"],
+            "title": "Past Filter Event",
+            "description": "ended",
+            "start_datetime": (datetime.now(UTC) - timedelta(days=2)).isoformat(),
+            "end_datetime": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+            "visibility": "public",
+            "status": "ended",
+            "is_age_restricted": False,
+            "attendee_count": 0,
+        }).execute()
+        ev_id = result.data[0]["id"]
+        db.table("event_categories").insert({"event_id": ev_id, "category_id": cat_ids[0]}).execute()
+
+        resp = client.get("/events?quick_filter=past")
+        assert resp.status_code == 200
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev_id in ids
+
+        # And the past event is NOT in default listing
+        resp_default = client.get("/events")
+        default_ids = [i["id"] for i in resp_default.json()["items"]]
+        assert ev_id not in default_ids
+
+        _cleanup_event(ev_id)
+        _cleanup_user(user["id"])
+
+    def test_now_filter_returns_currently_running(self):
+        """quick_filter=now returns events where start <= now <= end."""
+        user = _create_test_user("nowflt")
+        cat_ids = _get_category_ids(1)
+        from datetime import UTC, datetime, timedelta
+        # Currently running event
+        running = db.table("events").insert({
+            "host_id": user["id"],
+            "title": "Now Running",
+            "description": "running",
+            "start_datetime": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+            "end_datetime": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+            "visibility": "public",
+            "status": "published",
+            "is_age_restricted": False,
+            "attendee_count": 0,
+        }).execute().data[0]
+        db.table("event_categories").insert({"event_id": running["id"], "category_id": cat_ids[0]}).execute()
+        # Future event (should not appear under "now")
+        future = _create_published_event(user["id"], cat_ids, title="Future", days_from_now=3)
+
+        resp = client.get("/events?quick_filter=now")
+        assert resp.status_code == 200
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert running["id"] in ids
+        assert future["id"] not in ids
+
+        _cleanup_event(running["id"])
+        _cleanup_event(future["id"])
+        _cleanup_user(user["id"])
+
+
+class TestListEventsCustomWindow:
+    """start_after / end_before custom time window."""
+
+    def test_quick_filter_mutex_with_custom_window(self):
+        resp = client.get("/events?quick_filter=today&start_after=2030-01-01T00:00:00Z")
+        assert resp.status_code == 422
+
+    def test_start_after_filters_earlier_events(self):
+        user = _create_test_user("after")
+        cat_ids = _get_category_ids(1)
+        ev_soon = _create_published_event(user["id"], cat_ids, title="Soon", days_from_now=1)
+        ev_far = _create_published_event(user["id"], cat_ids, title="Far", days_from_now=10)
+
+        cutoff = (datetime.now(UTC) + timedelta(days=5)).isoformat()
+        resp = client.get("/events", params={"start_after": cutoff})
+        assert resp.status_code == 200, resp.text
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev_soon["id"] not in ids
+        assert ev_far["id"] in ids
+
+        _cleanup_event(ev_soon["id"])
+        _cleanup_event(ev_far["id"])
+        _cleanup_user(user["id"])
+
+    def test_start_after_must_be_before_end_before(self):
+        resp = client.get(
+            "/events?start_after=2030-12-31T00:00:00Z&end_before=2030-01-01T00:00:00Z"
+        )
+        assert resp.status_code == 422
+
+
+class TestListEventsAccessibility:
+    """Accessibility filtering against venue_metadata."""
+
+    def test_wheelchair_filter(self):
+        user = _create_test_user("acca11y")
+        cat_ids = _get_category_ids(1)
+        ev_with = _create_published_event(user["id"], cat_ids, title="A11y Yes", days_from_now=2)
+        ev_without = _create_published_event(user["id"], cat_ids, title="A11y No", days_from_now=2)
+        # Insert venue metadata with wheelchair=true on one event
+        db.table("venue_metadata").insert({
+            "event_id": ev_with["id"],
+            "wheelchair_access": True,
+            "accessible_restroom": False,
+            "elevator_available": False,
+            "seating_available": False,
+            "captions_support": False,
+            "quiet_friendly": False,
+        }).execute()
+
+        resp = client.get("/events?wheelchair=true")
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev_with["id"] in ids
+        assert ev_without["id"] not in ids
+
+        _cleanup_event(ev_with["id"])
+        _cleanup_event(ev_without["id"])
+        _cleanup_user(user["id"])
+
+
+class TestListEventsLocation:
+    """near_lat/near_lng/radius_km bounding-box and distance sort."""
+
+    def test_near_lat_without_lng_rejected(self):
+        resp = client.get("/events?near_lat=41.0")
+        assert resp.status_code == 422
+
+    def test_radius_without_location_rejected(self):
+        resp = client.get("/events?radius_km=10")
+        assert resp.status_code == 422
+
+    def test_distance_sort_without_location_rejected(self):
+        resp = client.get("/events?sort=distance")
+        assert resp.status_code == 422
+
+    def test_bounding_box_filter(self):
+        user = _create_test_user("bbox")
+        cat_ids = _get_category_ids(1)
+        # Istanbul at (41.0, 29.0). _create_published_event uses these coords by default.
+        ev_near = _create_published_event(user["id"], cat_ids, title="Near", days_from_now=2)
+        # Override another event's location to a very distant place (Tokyo)
+        ev_far = _create_published_event(user["id"], cat_ids, title="Far", days_from_now=2)
+        db.table("event_locations").update({"latitude": 35.68, "longitude": 139.69}).eq("event_id", ev_far["id"]).execute()
+
+        resp = client.get("/events?near_lat=41.0&near_lng=29.0&radius_km=100")
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev_near["id"] in ids
+        assert ev_far["id"] not in ids
+
+        _cleanup_event(ev_near["id"])
+        _cleanup_event(ev_far["id"])
+        _cleanup_user(user["id"])
+
+    def test_distance_sort_orders_closer_first(self):
+        user = _create_test_user("distsort")
+        cat_ids = _get_category_ids(1)
+        ev_close = _create_published_event(user["id"], cat_ids, title="Close", days_from_now=2)
+        ev_medium = _create_published_event(user["id"], cat_ids, title="Medium", days_from_now=2)
+        # Move medium event ~30km away (still inside default 50km radius)
+        db.table("event_locations").update({"latitude": 41.27, "longitude": 29.0}).eq("event_id", ev_medium["id"]).execute()
+
+        resp = client.get("/events?near_lat=41.0&near_lng=29.0&sort=distance")
+        ids = [i["id"] for i in resp.json()["items"]]
+        # close before medium
+        if ev_close["id"] in ids and ev_medium["id"] in ids:
+            assert ids.index(ev_close["id"]) < ids.index(ev_medium["id"])
+
+        _cleanup_event(ev_close["id"])
+        _cleanup_event(ev_medium["id"])
+        _cleanup_user(user["id"])
+
+
+class TestListEventsDefaultArea:
+    """use_default_area falls back to authenticated user's stored profile lat/lng."""
+
+    def test_default_area_requires_auth(self):
+        resp = client.get("/events?use_default_area=true")
+        assert resp.status_code == 422
+
+    def test_default_area_requires_stored_default(self):
+        user = _create_test_user("nodefault")
+        # User has no default_location_* set
+        resp = client.get("/events?use_default_area=true", headers=_auth_header(user["id"]))
+        assert resp.status_code == 422
+        _cleanup_user(user["id"])
+
+    def test_default_area_used_when_no_explicit_coords(self):
+        user = _create_test_user("withdef")
+        db.table("users").update({
+            "default_location_name": "Istanbul",
+            "default_location_lat": 41.0,
+            "default_location_lng": 29.0,
+        }).eq("id", user["id"]).execute()
+        cat_ids = _get_category_ids(1)
+        ev_near = _create_published_event(user["id"], cat_ids, title="DefArea", days_from_now=2)
+
+        resp = client.get(
+            "/events?use_default_area=true&radius_km=100",
+            headers=_auth_header(user["id"]),
+        )
+        assert resp.status_code == 200, resp.text
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev_near["id"] in ids
+
+        _cleanup_event(ev_near["id"])
         _cleanup_user(user["id"])

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -818,3 +818,121 @@ class TestListEventsDefaultArea:
 
         _cleanup_event(ev_near["id"])
         _cleanup_user(user["id"])
+
+
+class TestListEventsCaptionsRename:
+    """The accessibility filter previously named `sign_language` is now `captions`.
+
+    The old name was misleading — captions and sign-language interpretation
+    are different features and the underlying DB column is `captions_support`.
+    """
+
+    def test_captions_filter_matches_captions_support_column(self):
+        user = _create_test_user("captions")
+        cat_ids = _get_category_ids(1)
+        ev_with = _create_published_event(user["id"], cat_ids, title="WithCaptions", days_from_now=2)
+        ev_without = _create_published_event(user["id"], cat_ids, title="NoCaptions", days_from_now=2)
+        db.table("venue_metadata").insert({
+            "event_id": ev_with["id"],
+            "wheelchair_access": False,
+            "accessible_restroom": False,
+            "elevator_available": False,
+            "seating_available": False,
+            "captions_support": True,
+            "quiet_friendly": False,
+        }).execute()
+
+        resp = client.get("/events?captions=true")
+        assert resp.status_code == 200, resp.text
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev_with["id"] in ids
+        assert ev_without["id"] not in ids
+
+        _cleanup_event(ev_with["id"])
+        _cleanup_event(ev_without["id"])
+        _cleanup_user(user["id"])
+
+    def test_old_sign_language_param_no_longer_filters(self):
+        """sign_language is no longer a recognised query parameter; passing it
+        is silently ignored by FastAPI rather than rejected, but it must not
+        accidentally apply the captions filter (the misleading old behaviour)."""
+        user = _create_test_user("oldsl")
+        cat_ids = _get_category_ids(1)
+        ev = _create_published_event(user["id"], cat_ids, title="StillVisible", days_from_now=2)
+        # Insert venue metadata with captions_support=False so if sign_language
+        # were still mapping to captions_support, this event would be excluded.
+        db.table("venue_metadata").insert({
+            "event_id": ev["id"],
+            "wheelchair_access": False,
+            "accessible_restroom": False,
+            "elevator_available": False,
+            "seating_available": False,
+            "captions_support": False,
+            "quiet_friendly": False,
+        }).execute()
+
+        resp = client.get("/events?sign_language=true")
+        assert resp.status_code == 200, resp.text
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev["id"] in ids
+
+        _cleanup_event(ev["id"])
+        _cleanup_user(user["id"])
+
+
+class TestListEventsCategorySort:
+    """sort=category requires a narrowing filter to keep memory bounded."""
+
+    def test_sort_category_without_narrowing_filter_rejected(self):
+        resp = client.get("/events?sort=category")
+        assert resp.status_code == 422
+        assert "narrowing filter" in resp.json()["detail"].lower()
+
+    def test_sort_category_accepted_with_search(self):
+        user = _create_test_user("catsearch")
+        cat_ids = _get_category_ids(1)
+        ev = _create_published_event(user["id"], cat_ids, title="UniqueCatSortTitle", days_from_now=2)
+
+        resp = client.get("/events?sort=category&search=UniqueCatSortTitle")
+        assert resp.status_code == 200, resp.text
+        ids = [i["id"] for i in resp.json()["items"]]
+        assert ev["id"] in ids
+
+        _cleanup_event(ev["id"])
+        _cleanup_user(user["id"])
+
+    def test_sort_category_accepted_with_quick_filter(self):
+        resp = client.get("/events?sort=category&quick_filter=upcoming")
+        assert resp.status_code == 200, resp.text
+
+    def test_sort_category_accepted_with_category_id(self):
+        cat_ids = _get_category_ids(1)
+        resp = client.get(f"/events?sort=category&category_id={cat_ids[0]}")
+        assert resp.status_code == 200, resp.text
+
+    def test_sort_category_accepted_with_location(self):
+        resp = client.get("/events?sort=category&near_lat=41.0&near_lng=29.0")
+        assert resp.status_code == 200, resp.text
+
+    def test_sort_category_accepted_with_accessibility(self):
+        resp = client.get("/events?sort=category&wheelchair=true")
+        assert resp.status_code == 200, resp.text
+
+    def test_sort_category_orders_alphabetically(self):
+        user = _create_test_user("catorder")
+        cat_ids = _get_category_ids(1)
+        # Same category bucket → tiebreaker on start_datetime
+        ev_first = _create_published_event(user["id"], cat_ids, title="ZZZcatA", days_from_now=2)
+        ev_second = _create_published_event(user["id"], cat_ids, title="ZZZcatB", days_from_now=3)
+
+        # Use search to satisfy the narrowing-filter requirement.
+        resp = client.get("/events?sort=category&search=ZZZcat")
+        assert resp.status_code == 200, resp.text
+        ids = [i["id"] for i in resp.json()["items"]]
+        if ev_first["id"] in ids and ev_second["id"] in ids:
+            # Same category → start_datetime tiebreaker → ev_first earlier
+            assert ids.index(ev_first["id"]) < ids.index(ev_second["id"])
+
+        _cleanup_event(ev_first["id"])
+        _cleanup_event(ev_second["id"])
+        _cleanup_user(user["id"])


### PR DESCRIPTION
Closes #148

## Summary

Extends `GET /events` beyond the MVP discovery surface to satisfy the final-milestone discovery requirements: quick time-window filters, custom time windows, accessibility filtering against venue metadata, geographic bounding-box filtering, distance-aware ranking, the persisted-default-area fallback, capacity status exposure, and host-profile past events alongside upcoming ones.

Closes the discovery filters / distance ranking / persisted default map area task.

## What changed

### New query contract on `GET /events`

| Param | Type | Notes |
|---|---|---|
| `quick_filter` | `now \| today \| weekend \| upcoming \| this_week \| past` | Mutually exclusive with `start_after`/`end_before` (422 otherwise) |
| `start_after`, `end_before` | ISO datetime | Custom window; `start_after` must be earlier than `end_before` |
| `near_lat`, `near_lng` | float (-90..90, -180..180) | Must be provided together |
| `radius_km` | float (>0, ≤500) | Default 50 when location is provided. Requires `near_lat/lng` or `use_default_area`. |
| `use_default_area` | bool | Falls back to the authenticated user's stored profile default location. Requires auth (422 otherwise) and a stored default (422 otherwise). Ignored when explicit `near_lat/lng` are provided. |
| `wheelchair`, `accessible_restroom`, `elevator`, `seating`, `sign_language`, `quiet_friendly` | bool | Each filters against the corresponding `venue_metadata` column. Combinable with each other and with all other filters. |
| `sort` | `start_time \| distance \| category` | Defaults to `distance` when location is present, otherwise `start_time`. `sort=distance` without a location is rejected with 422. |
| `search`, `category_id`, `page`, `page_size` | unchanged | |

The legacy `temporal_filter` parameter has been replaced by `quick_filter`, which is a strict superset (`now`, `weekend`, and `past` added, `upcoming/today/this_week` retained). Existing tests have been migrated.

### Filter pipeline (repository)

Whitelists are derived from the related tables (`event_categories`, `venue_metadata`, `event_locations`) and intersected before the events table is queried. If any whitelist resolves to an empty set, the query short-circuits to `[]`.

- **Bounding box**: a degree-approximation box (`lat_delta = radius_km / 111.32`, longitude scaled by `cos(lat)`) is computed from `(near_lat, near_lng, radius_km)`, and `event_locations` is filtered against it (primary-only). This keeps the candidate set small enough for in-memory distance ranking to remain fast.
- **Accessibility**: requested booleans are AND-combined into a single PostgREST query against `venue_metadata`.
- **Past mode** (`quick_filter=past`): inverts the default end-datetime filter (now `end_datetime < now`) and broadens status to include `ended`. Results are sorted by start_datetime DESC by default.

### Ranking

For `sort=start_time` (the cheap path) the database performs `ORDER BY start_datetime` with `OFFSET/LIMIT` pagination. For `sort=distance` and `sort=category` the repo returns the full filtered candidate set and the service computes the ranking key in Python and slices to the requested page:

- **distance**: Haversine great-circle distance against `(near_lat, near_lng)`, ascending. Candidates without a primary location sink to the end.
- **category**: ascending by the alphabetically-first category name of each event, with `start_datetime` and id as tiebreakers.

The bounding-box pre-filter ensures the in-memory set stays bounded for `sort=distance` even on a 10k-event dataset.

### Default-area resolution

When `use_default_area=true` is passed without explicit coordinates, the service reads `default_location_lat` / `default_location_lng` from the authenticated user's row directly. Validation ordering keeps router-level checks explicit (auth required, location required for `sort=distance`, `radius_km` requires either explicit coords or `use_default_area`).

### Host profile past events (FRS-10.2)

`GET /users/{id}/profile` already returned both past and upcoming hosted events; this PR improves the ordering so the response surfaces upcoming events first (chronological) followed by past events (most recent first) for a sensible default profile layout.

### Capacity status

`is_full` was already present on `EventListItemResponse` (computed as `attendee_count >= attendee_limit`); preserved as-is.

## Tests

48/48 in `tests/test_discovery.py` pass locally. New coverage in `tests/test_discovery.py`:

- `TestListEventsNewQuickFilters`: `past` returns ended events while excluding them from the default listing; `now` returns currently-running events and excludes future ones.
- `TestListEventsCustomWindow`: `quick_filter` × custom window mutex (422); `start_after` excludes earlier events; inverted custom window rejected (422).
- `TestListEventsAccessibility`: `wheelchair=true` returns only events whose `venue_metadata.wheelchair_access=true`.
- `TestListEventsLocation`: `near_lat` without `near_lng` rejected (422); `radius_km` without location rejected (422); `sort=distance` without location rejected (422); bounding-box filter excludes far-away events; `sort=distance` orders closer events first.
- `TestListEventsDefaultArea`: `use_default_area=true` requires auth (422); requires a stored default (422); falls back to the stored default when no explicit coords are provided.

Existing tests covering temporal filters were migrated from `temporal_filter` to `quick_filter`.

## API docs

The endpoint now carries an OpenAPI summary + description, and every new query parameter has its own `description=` entry that surfaces in the auto-generated docs.

## Out of scope (intentionally)

- **Avatar fields on user-bearing responses**: the ticket scope is filters/ranking/capacity/default-area, not user identity rendering. No backend response model gained an avatar field.
- **Mobile / web client updates**: the new query params are additive; existing clients keep working with their current request shape (the only breaking rename is `temporal_filter` → `quick_filter`, which neither client appears to use today).
- **Postgres `earthdistance` / RPC-based distance**: bounding-box pre-filter + in-memory Haversine is sufficient for the 10k target. Worth revisiting only if profiling shows the in-memory step becoming dominant.

## Test plan

- [ ] CI runs the full backend suite green (the local discovery suite is green; non-discovery suites were skipped locally and rely on CI).
- [ ] Manual smoke against a populated environment:
  - `GET /events?quick_filter=past` returns ended events; `GET /events` does not.
  - `GET /events?quick_filter=now` returns currently-running events.
  - `GET /events?wheelchair=true&accessible_restroom=true` returns only events whose venue metadata has both flags.
  - `GET /events?near_lat=41.0&near_lng=29.0&radius_km=10` excludes far events; same query with `sort=distance` orders the closest first.
  - `GET /events?use_default_area=true` (authenticated, with `default_location_*` set) behaves like an explicit `near_lat/lng` query.
  - `GET /users/{host_id}/profile` lists upcoming events before past events.
- [ ] OpenAPI doc (`/docs`) shows the new parameters with their descriptions and the endpoint summary.
