### PR TITLE
feat(backend): itinerary segments + lifecycle gaps (issue #149)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 # Local notes (not for repo)
 IMPROVEMENTS.md
 ISSUE_154_ROADMAP.md
+ISSUE_149_ROADMAP.md

--- a/backend/README.md
+++ b/backend/README.md
@@ -211,6 +211,59 @@ Notes:
 | PATCH | /events/{id}/status | Bearer | Change status: draft→published, cancel, end |
 | DELETE | /events/{id} | Bearer | Delete event (host only, must be cancelled/ended) |
 
+**Duplicate detection:** creating an event with the same `title`, `start_datetime`, and *primary* location as another event from the same host returns `409 Conflict`. Non-primary stop name collisions are intentionally allowed.
+
+**Lifecycle constraints:** once `start_datetime` is in the past, `time`, `locations`, and `segments` updates are rejected with `400`. Status changes follow `draft → published`, `published/updated → cancelled/ended`. Only `cancelled` or `ended` events can be deleted.
+
+#### Itinerary segments (multi-stop events)
+
+Both `POST /events` and `PUT /events/{id}` accept an optional `segments` array. Each segment ties a single location (referenced by **position** in the request's `locations` array) to a time window with an optional description.
+
+```json
+{
+  "title": "City photo walk",
+  "start_datetime": "2030-06-01T09:00:00+00:00",
+  "end_datetime":   "2030-06-01T13:00:00+00:00",
+  "category_ids": ["..."],
+  "locations": [
+    {"name": "Galata Tower", "latitude": 41.025, "longitude": 28.974, "is_primary": true,  "order_index": 0},
+    {"name": "Karaköy Pier", "latitude": 41.022, "longitude": 28.978, "is_primary": false, "order_index": 1}
+  ],
+  "segments": [
+    {"location_index": 0, "order_index": 0,
+     "start_datetime": "2030-06-01T09:00:00+00:00",
+     "end_datetime":   "2030-06-01T10:30:00+00:00",
+     "description": "Meet at the tower"},
+    {"location_index": 1, "order_index": 1,
+     "start_datetime": "2030-06-01T11:00:00+00:00",
+     "end_datetime":   "2030-06-01T12:00:00+00:00",
+     "description": "Walk to the pier"}
+  ]
+}
+```
+
+Validation (`400` on failure):
+
+- `location_index` must be `0 ≤ i < len(locations)`
+- both timestamps must be timezone-aware; `end_datetime > start_datetime`
+- each segment must lie within `[event.start_datetime, event.end_datetime]`
+- `order_index` values must be contiguous from `0` (no gaps, no duplicates)
+- when sorted by `order_index`, segments must not overlap in time (the rule is location-independent)
+
+Update semantics on `PUT`:
+
+- omitting `segments` leaves existing segments untouched
+- `segments: []` clears all segments
+- providing a non-empty array fully replaces existing segments
+- replacing `locations` cascades through `event_segments.location_id`; the API rejects this with `400` unless `segments` is also re-sent (or set to `[]` to opt into clearing)
+
+`location_index` semantics:
+
+- on **create** and on **update with new `locations`**, `location_index` is the position in the request's `locations` array (`location_index = i` ⇔ `locations[i]`).
+- on **update that sends `segments` without `locations`**, `location_index` is the position in the locations array returned by the most recent `GET /events/{id}` (the API orders locations by `created_at`, then `order_index`, then `id`).
+
+`GET /events/{id}` includes `segments` ordered by `order_index`, each with the resolved `location_id`.
+
 ### Event Images
 
 | Method | Endpoint | Auth | Description |
@@ -248,9 +301,13 @@ Notes:
 **Query parameters** for `GET /notifications`: `page` (default 1), `page_size` (default 20, max 100).
 
 **Automatic emission:** Notifications are created automatically when:
-- An event is updated → `event_updated` sent to all going/interested/bookmarked users
-- An event is cancelled → `event_cancelled` sent to all going/interested/bookmarked users
-- The host is excluded from receiving their own notifications
+- An event is updated → `event_updated` sent to going attendees + bookmarkers
+- An event is cancelled → `event_cancelled` sent to going attendees + bookmarkers
+- An event is deleted → `event_deleted` sent to going attendees + bookmarkers (emitted *before* the row is removed; the notification's `event_id` is `NULL` after delete because the FK is `ON DELETE SET NULL`)
+- A user requests access to a private event → `access_request` sent to the host
+- A host approves an access request → `access_approved` sent to the requester
+- A host rejects an access request → `access_rejected` sent to the requester
+- The host is excluded from receiving their own action notifications
 
 ### Categories
 
@@ -336,14 +393,23 @@ backend/
 │   ├── test_comments.py      # Comment tests (20)
 │   ├── test_invites.py       # Invite/Access request tests (28)
 │   ├── test_notifications.py # Notification tests (12)
-│   ├── test_notification_emitter.py  # Notification emission tests (11)
+│   ├── test_notification_emitter.py  # Notification emission tests
+│   ├── test_segments_unit.py # Itinerary-segment + duplicate-detection unit tests
 │   └── test_health.py        # Health check test (1)
-├── sql/
-│   ├── 001_create_tables.sql         # Auth tables
-│   ├── 002_create_core_tables.sql    # Core data model tables
-│   ├── 003_pg_cron_auto_end.sql      # Auto-end expired events
-│   ├── 005_create_invite_tables.sql  # Invite/Access tables
-│   └── 006_reconcile_invite_schema.sql  # Manual Supabase reconcile script
+├── sql/                                # Apply manually in Supabase SQL Editor (no runner)
+│   ├── 001_create_tables.sql           # Auth tables
+│   ├── 002_create_core_tables.sql      # Core data model tables
+│   ├── 003_pg_cron_auto_end.sql        # Auto-end expired events
+│   ├── 004_revoke_public_access.sql    # Tighten RLS / public role
+│   ├── 005_create_invite_tables.sql    # Invite + access-request tables
+│   ├── 006_reconcile_invite_schema.sql # Reconcile invite schema + add notification types
+│   ├── 007_add_phone_visibility.sql    # Phone visibility column on profiles
+│   ├── 008_token_cleanup_cron.sql      # pg_cron job for refresh/verification token cleanup
+│   ├── 009_atomic_event_rpc.sql        # create_event_atomic RPC (superseded by 013)
+│   ├── 010_atomic_event_update_rpc.sql # update_event_atomic RPC (superseded by 013)
+│   ├── 011_add_comment_parent_id.sql   # Threaded comments
+│   ├── 012_create_event_segments.sql   # Itinerary segments table
+│   └── 013_atomic_event_rpc_segments.sql  # Replaces 009/010 with p_segments support
 ├── requirements.txt
 ├── pyproject.toml            # Ruff + pytest config
 ├── Dockerfile

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -58,6 +58,29 @@ class EquipmentResponse(BaseModel):
     is_required: bool
 
 
+class SegmentRequest(BaseModel):
+    """Single itinerary segment for an event.
+
+    location_index references a position in the request's locations[] array
+    (locations are inserted before segments inside the atomic RPC, so we use
+    positional indexing rather than a UUID the client cannot know yet).
+    """
+    location_index: int = Field(ge=0)
+    order_index: int = Field(ge=0)
+    start_datetime: datetime
+    end_datetime: datetime
+    description: str | None = Field(default=None, max_length=1000)
+
+
+class SegmentResponse(BaseModel):
+    id: UUID
+    location_id: UUID
+    order_index: int
+    start_datetime: datetime
+    end_datetime: datetime
+    description: str | None = None
+
+
 class CategoryResponse(BaseModel):
     id: UUID
     name: str
@@ -95,6 +118,7 @@ class EventCreateRequest(BaseModel):
     locations: list[LocationRequest] = Field(min_length=1)
     venue_metadata: VenueMetadataRequest | None = None
     equipment_requirements: list[EquipmentRequest] | None = None
+    segments: list[SegmentRequest] | None = None
 
 
 class EventUpdateRequest(BaseModel):
@@ -110,6 +134,7 @@ class EventUpdateRequest(BaseModel):
     locations: list[LocationRequest] | None = Field(default=None, min_length=1)
     venue_metadata: VenueMetadataRequest | None = None
     equipment_requirements: list[EquipmentRequest] | None = None
+    segments: list[SegmentRequest] | None = None
 
 
 # --- Event Response Schemas ---
@@ -141,6 +166,7 @@ class EventDetailResponse(BaseModel):
     venue_metadata: VenueMetadataResponse | None = None
     equipment_requirements: list[EquipmentResponse] = []
     attendees: list[AttendeeSummaryResponse] = []
+    segments: list[SegmentResponse] = []
 
 
 class StatusChangeRequest(BaseModel):

--- a/backend/app/repositories/event.py
+++ b/backend/app/repositories/event.py
@@ -16,6 +16,7 @@ _VENUE_COLS = (
     "elevator_available,seating_available,captions_support,quiet_friendly"
 )
 _EQUIPMENT_COLS = "id,event_id,item_name,is_required"
+_SEGMENT_COLS = "id,event_id,location_id,order_index,start_datetime,end_datetime,description"
 _RATE_LIMIT_COLS = "id,max_events_per_user,time_window_hours,updated_at"
 
 
@@ -28,14 +29,16 @@ def create_event_atomic(
     category_ids: list[str],
     venue_metadata: dict | None = None,
     equipment: list[dict] | None = None,
+    segments: list[dict] | None = None,
 ) -> dict:
-    """Create event + locations + categories + venue + equipment in a single DB transaction."""
+    """Create event + locations + categories + venue + equipment + segments in a single DB transaction."""
     params = {
         "p_event": event_data,
         "p_locations": locations,
         "p_categories": [{"category_id": cid} for cid in category_ids],
         "p_venue_metadata": venue_metadata,
         "p_equipment": equipment,
+        "p_segments": segments,
     }
     result = db.rpc("create_event_atomic", params).execute()
     return result.data
@@ -49,6 +52,7 @@ def update_event_atomic(
     category_ids: list[str] | None = None,
     venue_metadata: dict | None = None,
     equipment: list[dict] | None = None,
+    segments: list[dict] | None = None,
 ) -> dict:
     """Update event + related tables in a single DB transaction."""
     params = {
@@ -58,6 +62,7 @@ def update_event_atomic(
         "p_categories": [{"category_id": cid} for cid in category_ids] if category_ids is not None else None,
         "p_venue_metadata": venue_metadata,
         "p_equipment": equipment,
+        "p_segments": segments,
     }
     result = db.rpc("update_event_atomic", params).execute()
     return result.data
@@ -97,7 +102,19 @@ def get_event_by_id(db: Client, event_id: str) -> dict | None:
 
 
 def get_event_locations(db: Client, event_id: str) -> list[dict]:
-    result = db.table("event_locations").select(_LOCATION_COLS).eq("event_id", event_id).execute()
+    # Deterministic order — matches the fallback in update_event_atomic so
+    # that SegmentRequest.location_index against an *existing* location set
+    # (a PATCH that only sends `segments`) refers to the same position the
+    # client saw from this read.
+    result = (
+        db.table("event_locations")
+        .select(_LOCATION_COLS)
+        .eq("event_id", event_id)
+        .order("created_at")
+        .order("order_index")
+        .order("id")
+        .execute()
+    )
     return result.data or []
 
 
@@ -123,6 +140,17 @@ def get_venue_metadata(db: Client, event_id: str) -> dict | None:
 
 def get_equipment(db: Client, event_id: str) -> list[dict]:
     result = db.table("equipment_requirements").select(_EQUIPMENT_COLS).eq("event_id", event_id).execute()
+    return result.data or []
+
+
+def get_event_segments(db: Client, event_id: str) -> list[dict]:
+    result = (
+        db.table("event_segments")
+        .select(_SEGMENT_COLS)
+        .eq("event_id", event_id)
+        .order("order_index")
+        .execute()
+    )
     return result.data or []
 
 
@@ -181,11 +209,19 @@ def find_duplicate_events(db: Client, host_id: str, title: str, start_datetime: 
 
 
 def find_location_by_event_and_name(db: Client, event_id: str, name: str) -> list[dict]:
+    """Return matching primary-location rows for the event.
+
+    Scoped to is_primary=True so duplicate-event detection only fires when the
+    *primary* location matches (issue #149 FRS-2: "identical title +
+    start_datetime + primary location"). A non-primary stop with the same name
+    on the candidate event is intentionally not treated as a collision.
+    """
     result = (
         db.table("event_locations")
         .select("name")
         .eq("event_id", event_id)
         .eq("name", name)
+        .eq("is_primary", True)
         .execute()
     )
     return result.data or []

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -12,6 +12,8 @@ from app.models.event import (
     EventListItemResponse,
     EventListResponse,
     EventUpdateRequest,
+    SegmentRequest,
+    SegmentResponse,
 )
 from app.repositories import attendance as attendance_repo
 from app.repositories import bookmark as bookmark_repo
@@ -65,16 +67,103 @@ def validate_categories_exist(db: Client, category_ids: list[str]) -> None:
         )
 
 
+def validate_segments(
+    segments: list[SegmentRequest] | None,
+    location_count: int,
+    event_start: datetime,
+    event_end: datetime,
+) -> None:
+    """Validate itinerary segments against the issue's rules.
+
+    Rules (issue #149):
+      1. Each segment.location_index references a real position
+         (0 <= location_index < location_count).
+      2. Each segment is timezone-aware and end > start.
+      3. Each segment lies within [event_start, event_end].
+      4. order_index values are contiguous from 0 with no duplicates.
+      5. Sorted by order_index, segments do not overlap in time
+         (current.start >= previous.end).
+    """
+    if not segments:
+        return
+
+    # 1. location_index in range
+    for seg in segments:
+        if seg.location_index >= location_count:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"segment.location_index {seg.location_index} out of range "
+                       f"(locations has {location_count} entries)",
+            )
+
+    # 2. timezone + inverted time
+    for seg in segments:
+        _ensure_timezone_aware(seg.start_datetime, "segment.start_datetime")
+        _ensure_timezone_aware(seg.end_datetime, "segment.end_datetime")
+        if seg.end_datetime <= seg.start_datetime:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="segment end_datetime must be after start_datetime",
+            )
+
+    # 3. each segment within event window
+    for seg in segments:
+        if seg.start_datetime < event_start or seg.end_datetime > event_end:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="segment must lie within event start_datetime and end_datetime",
+            )
+
+    # 4. order_index contiguous from 0
+    order_values = sorted(seg.order_index for seg in segments)
+    for expected, actual in enumerate(order_values):
+        if actual != expected:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="segments must have contiguous order_index starting at 0",
+            )
+
+    # 5. no time overlaps when sorted by order
+    sorted_by_order = sorted(segments, key=lambda s: s.order_index)
+    for prev, curr in zip(sorted_by_order, sorted_by_order[1:], strict=False):
+        if curr.start_datetime < prev.end_datetime:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="segments must not overlap in time when sorted by order_index",
+            )
+
+
+def _build_segment_rows(segments: list[SegmentRequest] | None) -> list[dict] | None:
+    if segments is None:
+        return None
+    return [
+        {
+            "location_index": seg.location_index,
+            "order_index": seg.order_index,
+            "start_datetime": seg.start_datetime.isoformat(),
+            "end_datetime": seg.end_datetime.isoformat(),
+            "description": seg.description,
+        }
+        for seg in segments
+    ]
+
+
 def check_duplicate_event(
     db: Client, host_id: str, title: str, start_datetime: str, location_name: str
 ) -> None:
+    """Reject creation when title + start_datetime + *primary* location collide for the same host.
+
+    Issue #149 FRS-2 explicitly scopes this to the primary location. A separate
+    event whose primary differs but happens to include `location_name` as a
+    non-primary stop is allowed.
+    """
     events = event_repo.find_duplicate_events(db, host_id, title, start_datetime)
     for event in events:
         locations = event_repo.find_location_by_event_and_name(db, event["id"], location_name)
         if locations:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="A similar event already exists with the same title, time, and location",
+                detail="A similar event already exists with the same title, time, and primary location",
             )
 
 
@@ -134,6 +223,12 @@ def create_event(db: Client, user_id: str, body: EventCreateRequest) -> EventDet
     if not has_primary:
         body.locations[0].is_primary = True
 
+    # Itinerary segments (optional)
+    validate_segments(
+        body.segments, len(body.locations), body.start_datetime, body.end_datetime,
+    )
+    segment_rows = _build_segment_rows(body.segments)
+
     # Build atomic insert params
     event_data = {
         "host_id": user_id,
@@ -174,6 +269,7 @@ def create_event(db: Client, user_id: str, body: EventCreateRequest) -> EventDet
         category_ids=category_id_strs,
         venue_metadata=venue_data,
         equipment=equip_data,
+        segments=segment_rows,
     )
     if not event:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create event")
@@ -185,8 +281,11 @@ def create_event(db: Client, user_id: str, body: EventCreateRequest) -> EventDet
     categories = event_repo.get_event_categories(db, event_id)
     venue_meta = event_repo.get_venue_metadata(db, event_id)
     equipment = event_repo.get_equipment(db, event_id)
+    segments = event_repo.get_event_segments(db, event_id)
 
-    return _build_detail_response(event, locations, categories, [], venue_meta, equipment)
+    return _build_detail_response(
+        event, locations, categories, [], venue_meta, equipment, segments=segments,
+    )
 
 
 # --- Helpers ---
@@ -205,11 +304,25 @@ def _build_detail_response(
     access_request_status: str | None = None,
     attendees: list[dict] | None = None,
     host_username: str = "",
+    segments: list[dict] | None = None,
 ) -> EventDetailResponse:
     actual_going = going_count if going_count is not None else event["attendee_count"]
     is_full = None
     if event["attendee_limit"] is not None:
         is_full = actual_going >= event["attendee_limit"]
+
+    segment_rows = segments or []
+    segment_responses = [
+        SegmentResponse(
+            id=row["id"],
+            location_id=row["location_id"],
+            order_index=row["order_index"],
+            start_datetime=row["start_datetime"],
+            end_datetime=row["end_datetime"],
+            description=row.get("description"),
+        )
+        for row in segment_rows
+    ]
 
     return EventDetailResponse(
         id=event["id"],
@@ -238,6 +351,7 @@ def _build_detail_response(
         venue_metadata=venue_metadata,
         equipment_requirements=equipment,
         attendees=attendees or [],
+        segments=segment_responses,
     )
 
 
@@ -348,6 +462,7 @@ def get_event_detail(
     images = event_repo.get_event_images(db, event_id)
     venue_metadata = event_repo.get_venue_metadata(db, event_id)
     equipment = event_repo.get_equipment(db, event_id)
+    segments = event_repo.get_event_segments(db, event_id)
     attendee_ids = attendance_repo.get_going_user_ids_for_event(db, event_id)
     attendee_users = user_repo.get_users_by_ids(db, attendee_ids)
     attendee_usernames = {
@@ -371,6 +486,7 @@ def get_event_detail(
         access_request_status=access_request_status,
         attendees=attendees,
         host_username=host_username,
+        segments=segments,
     )
 
 
@@ -426,12 +542,40 @@ def update_event(
                 detail="Cannot modify locations after event has started",
             )
 
+    # Itinerary segments — same lifecycle constraint as time/locations (FRS-2)
+    if body.segments is not None and event_started:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot modify segments after event has started",
+        )
+
+    if body.segments is not None:
+        # Validate against the *effective* locations and event window.
+        # body fields shadow stored values when provided; otherwise fall back to DB.
+        if body.locations is not None:
+            effective_location_count = len(body.locations)
+        else:
+            effective_location_count = len(event_repo.get_event_locations(db, event_id))
+
+        effective_start = body.start_datetime or _parse_stored_datetime(event["start_datetime"])
+        effective_end = body.end_datetime or _parse_stored_datetime(event["end_datetime"])
+        validate_segments(
+            body.segments, effective_location_count, effective_start, effective_end,
+        )
+
     if body.category_ids is not None:
         category_id_strs = [str(cid) for cid in body.category_ids]
         validate_categories_exist(db, category_id_strs)
 
     # Set status to "updated" if currently published
-    has_real_changes = bool(update_data) or body.locations is not None or body.category_ids is not None or body.venue_metadata is not None or body.equipment_requirements is not None
+    has_real_changes = (
+        bool(update_data)
+        or body.locations is not None
+        or body.category_ids is not None
+        or body.venue_metadata is not None
+        or body.equipment_requirements is not None
+        or body.segments is not None
+    )
     if event["status"] == "published" and has_real_changes:
         update_data["status"] = "updated"
 
@@ -461,6 +605,20 @@ def update_event(
     if body.equipment_requirements is not None:
         equip_data = [eq.model_dump() for eq in body.equipment_requirements]
 
+    segment_rows = _build_segment_rows(body.segments)
+
+    # Replacing locations CASCADEs through event_segments.location_id, so
+    # require the caller to re-send segments alongside locations (or send []
+    # to explicitly clear them) — silent loss is worse than a clear error.
+    if body.locations is not None and body.segments is None:
+        existing_segments = event_repo.get_event_segments(db, event_id)
+        if existing_segments:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Updating locations clears existing segments. "
+                       "Re-send `segments` (or [] to clear) along with `locations`.",
+            )
+
     # Single-transaction update via RPC
     if has_real_changes or update_data:
         event_repo.update_event_atomic(
@@ -471,6 +629,7 @@ def update_event(
             category_ids=cat_id_strs,
             venue_metadata=venue_data,
             equipment=equip_data,
+            segments=segment_rows,
         )
 
     # Emit notification only if there were real changes
@@ -559,6 +718,17 @@ def delete_event(db: Client, event_id: str, user_id: str) -> None:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Only cancelled or ended events can be deleted",
         )
+
+    # Emit event_deleted notification *before* the row is removed.
+    # _get_affected_user_ids reads bookmarks + 'going' attendances, both of
+    # which CASCADE on event delete — so this must run first. The
+    # notifications.event_id FK is ON DELETE SET NULL, so the rows survive
+    # the subsequent delete with event_id cleared.
+    from app.services.notification_emitter import emit_event_notification
+    emit_event_notification(
+        db, event_id, user_id, "event_deleted",
+        f"Event '{event['title']}' has been deleted by the host",
+    )
 
     # Clean up storage images before DB delete (CASCADE will remove DB records)
     images = image_repo.get_all_event_images(db, event_id)

--- a/backend/sql/012_create_event_segments.sql
+++ b/backend/sql/012_create_event_segments.sql
@@ -1,0 +1,20 @@
+-- 012: Itinerary segments for multi-location events
+-- Each segment ties a single event_locations row to a time window with optional description.
+-- Segments are optional — events without segments continue to work unchanged (backward compatible).
+-- Run this in the Supabase SQL Editor.
+
+CREATE TABLE IF NOT EXISTS public.event_segments (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_id       UUID        NOT NULL REFERENCES public.events(id)          ON DELETE CASCADE,
+    location_id    UUID        NOT NULL REFERENCES public.event_locations(id) ON DELETE CASCADE,
+    order_index    INT         NOT NULL,
+    start_datetime TIMESTAMPTZ NOT NULL,
+    end_datetime   TIMESTAMPTZ NOT NULL,
+    description    TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT segment_end_after_start CHECK (end_datetime > start_datetime),
+    CONSTRAINT segment_order_unique    UNIQUE (event_id, order_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_segments_event_id ON public.event_segments (event_id, order_index);
+CREATE INDEX IF NOT EXISTS idx_event_segments_location ON public.event_segments (location_id);

--- a/backend/sql/013_atomic_event_rpc_segments.sql
+++ b/backend/sql/013_atomic_event_rpc_segments.sql
@@ -1,0 +1,338 @@
+-- 013: Extend atomic event RPCs to insert/replace itinerary segments
+-- Replaces 009_atomic_event_rpc.sql and 010_atomic_event_update_rpc.sql:
+--   - adds optional p_segments JSONB parameter to both RPCs
+--   - resolves each segment's location by *request-array position*
+--     (the index that the client sees when reading p_locations[i])
+--
+-- Why the explicit FOR loop?
+--   The client's SegmentRequest.location_index = "the i in locations[i]".
+--   `INSERT ... SELECT ... ORDER BY ... RETURNING id` does NOT officially
+--   guarantee that RETURNING yields rows in SELECT order — only that it
+--   returns one row per inserted row. We therefore insert locations one
+--   at a time, in request order, and accumulate the resulting UUIDs into
+--   v_location_ids[]. This keeps the contract `v_location_ids[i+1] ==
+--   id of p_locations[i]` rock solid.
+--
+--   On update, when only segments are sent (no locations), v_location_ids
+--   is populated from existing rows ordered (created_at, order_index, id).
+--   That ORDER BY is mirrored in app/repositories/event.py::get_event_locations
+--   so the client's `location_index` references the same positional list
+--   it just read from GET /events/{id}.
+--
+-- Backward compatible: passing NULL or omitting p_segments behaves exactly
+-- like 009/010 — no segments are inserted.
+--
+-- Run this in the Supabase SQL Editor AFTER 012_create_event_segments.sql.
+
+-- ----------------------------------------------------------------
+-- create_event_atomic
+-- ----------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION create_event_atomic(
+    p_event JSONB,
+    p_locations JSONB,
+    p_categories JSONB,
+    p_venue_metadata JSONB DEFAULT NULL,
+    p_equipment JSONB DEFAULT NULL,
+    p_segments JSONB DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_event_id UUID;
+    v_result JSONB;
+    v_location_ids UUID[] := ARRAY[]::UUID[];
+    v_loc_count INT;
+    v_segment_location_id UUID;
+    v_seg JSONB;
+    v_loc JSONB;
+    v_inserted_id UUID;
+    v_loc_idx INT;
+BEGIN
+    -- Insert event
+    INSERT INTO public.events (
+        host_id, title, description, start_datetime, end_datetime,
+        visibility, is_age_restricted, attendee_limit, status
+    )
+    SELECT
+        (p_event->>'host_id')::UUID,
+        p_event->>'title',
+        p_event->>'description',
+        (p_event->>'start_datetime')::TIMESTAMPTZ,
+        (p_event->>'end_datetime')::TIMESTAMPTZ,
+        p_event->>'visibility',
+        (p_event->>'is_age_restricted')::BOOLEAN,
+        (p_event->>'attendee_limit')::INTEGER,
+        p_event->>'status'
+    RETURNING id INTO v_event_id;
+
+    -- Insert locations one at a time, in request order, capturing the
+    -- resulting UUIDs into v_location_ids. v_location_ids[i+1] then
+    -- corresponds to p_locations[i] (PL/pgSQL arrays are 1-indexed).
+    FOR v_loc IN
+        SELECT loc FROM jsonb_array_elements(p_locations) WITH ORDINALITY AS t(loc, ord) ORDER BY ord
+    LOOP
+        INSERT INTO public.event_locations (
+            event_id, name, latitude, longitude, is_primary, order_index
+        ) VALUES (
+            v_event_id,
+            v_loc->>'name',
+            (v_loc->>'latitude')::DOUBLE PRECISION,
+            (v_loc->>'longitude')::DOUBLE PRECISION,
+            (v_loc->>'is_primary')::BOOLEAN,
+            (v_loc->>'order_index')::INTEGER
+        )
+        RETURNING id INTO v_inserted_id;
+        v_location_ids := array_append(v_location_ids, v_inserted_id);
+    END LOOP;
+
+    v_loc_count := COALESCE(array_length(v_location_ids, 1), 0);
+
+    -- Insert categories
+    INSERT INTO public.event_categories (event_id, category_id)
+    SELECT v_event_id, (cat->>'category_id')::UUID
+    FROM jsonb_array_elements(p_categories) AS cat;
+
+    -- Insert venue metadata (optional)
+    IF p_venue_metadata IS NOT NULL THEN
+        INSERT INTO public.venue_metadata (
+            event_id, price, language, health_requirements, wheelchair_access, accessible_restroom,
+            elevator_available, seating_available, captions_support, quiet_friendly
+        ) VALUES (
+            v_event_id,
+            p_venue_metadata->>'price',
+            p_venue_metadata->>'language',
+            p_venue_metadata->>'health_requirements',
+            (p_venue_metadata->>'wheelchair_access')::BOOLEAN,
+            (p_venue_metadata->>'accessible_restroom')::BOOLEAN,
+            (p_venue_metadata->>'elevator_available')::BOOLEAN,
+            (p_venue_metadata->>'seating_available')::BOOLEAN,
+            (p_venue_metadata->>'captions_support')::BOOLEAN,
+            (p_venue_metadata->>'quiet_friendly')::BOOLEAN
+        );
+    END IF;
+
+    -- Insert equipment requirements (optional)
+    IF p_equipment IS NOT NULL THEN
+        INSERT INTO public.equipment_requirements (event_id, item_name, is_required)
+        SELECT
+            v_event_id,
+            eq->>'item_name',
+            (eq->>'is_required')::BOOLEAN
+        FROM jsonb_array_elements(p_equipment) AS eq;
+    END IF;
+
+    -- Insert segments (optional). location_index is 0-based into the
+    -- request's locations array; v_location_ids is 1-based, so add 1.
+    IF p_segments IS NOT NULL AND jsonb_array_length(p_segments) > 0 THEN
+        FOR v_seg IN SELECT * FROM jsonb_array_elements(p_segments) LOOP
+            v_loc_idx := (v_seg->>'location_index')::INT;
+            IF v_loc_idx < 0 OR v_loc_idx >= v_loc_count THEN
+                RAISE EXCEPTION 'segment.location_index % out of range', v_loc_idx
+                    USING ERRCODE = 'check_violation';
+            END IF;
+            v_segment_location_id := v_location_ids[v_loc_idx + 1];
+
+            INSERT INTO public.event_segments (
+                event_id, location_id, order_index, start_datetime, end_datetime, description
+            ) VALUES (
+                v_event_id,
+                v_segment_location_id,
+                (v_seg->>'order_index')::INT,
+                (v_seg->>'start_datetime')::TIMESTAMPTZ,
+                (v_seg->>'end_datetime')::TIMESTAMPTZ,
+                v_seg->>'description'
+            );
+        END LOOP;
+    END IF;
+
+    -- Return the created event
+    SELECT to_jsonb(e) INTO v_result
+    FROM public.events e
+    WHERE e.id = v_event_id;
+
+    RETURN v_result;
+END;
+$$;
+
+
+-- ----------------------------------------------------------------
+-- update_event_atomic
+-- ----------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION update_event_atomic(
+    p_event_id UUID,
+    p_event_data JSONB DEFAULT NULL,
+    p_locations JSONB DEFAULT NULL,
+    p_categories JSONB DEFAULT NULL,
+    p_venue_metadata JSONB DEFAULT NULL,
+    p_equipment JSONB DEFAULT NULL,
+    p_segments JSONB DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_result JSONB;
+    v_key TEXT;
+    v_update_sql TEXT := '';
+    v_first BOOLEAN := TRUE;
+    v_location_ids UUID[];
+    v_loc_count INT;
+    v_segment_location_id UUID;
+    v_seg JSONB;
+    v_loc JSONB;
+    v_inserted_id UUID;
+    v_loc_idx INT;
+BEGIN
+    -- Update event fields (dynamic based on provided keys)
+    IF p_event_data IS NOT NULL AND p_event_data != '{}'::JSONB THEN
+        v_update_sql := 'UPDATE public.events SET ';
+        FOR v_key IN SELECT jsonb_object_keys(p_event_data) LOOP
+            IF NOT v_first THEN
+                v_update_sql := v_update_sql || ', ';
+            END IF;
+            v_first := FALSE;
+
+            CASE v_key
+                WHEN 'start_datetime', 'end_datetime' THEN
+                    v_update_sql := v_update_sql || v_key || ' = (' || quote_literal(p_event_data->>v_key) || ')::TIMESTAMPTZ';
+                WHEN 'is_age_restricted' THEN
+                    v_update_sql := v_update_sql || v_key || ' = (' || quote_literal(p_event_data->>v_key) || ')::BOOLEAN';
+                WHEN 'attendee_limit' THEN
+                    IF p_event_data->>v_key IS NULL THEN
+                        v_update_sql := v_update_sql || v_key || ' = NULL';
+                    ELSE
+                        v_update_sql := v_update_sql || v_key || ' = (' || quote_literal(p_event_data->>v_key) || ')::INTEGER';
+                    END IF;
+                ELSE
+                    v_update_sql := v_update_sql || v_key || ' = ' || quote_literal(p_event_data->>v_key);
+            END CASE;
+        END LOOP;
+        v_update_sql := v_update_sql || ' WHERE id = ' || quote_literal(p_event_id);
+        EXECUTE v_update_sql;
+    END IF;
+
+    -- Replace locations
+    -- Note: deleting locations cascades to event_segments.location_id, so when
+    -- p_locations is provided, any existing segments that referenced the old
+    -- locations are wiped. Callers must therefore re-send segments alongside
+    -- locations on update if they want to keep them. Same per-row insert
+    -- pattern as create_event_atomic to anchor request-array positions to
+    -- v_location_ids deterministically.
+    IF p_locations IS NOT NULL THEN
+        DELETE FROM public.event_locations WHERE event_id = p_event_id;
+        v_location_ids := ARRAY[]::UUID[];
+        FOR v_loc IN
+            SELECT loc FROM jsonb_array_elements(p_locations) WITH ORDINALITY AS t(loc, ord) ORDER BY ord
+        LOOP
+            INSERT INTO public.event_locations (
+                event_id, name, latitude, longitude, is_primary, order_index
+            ) VALUES (
+                p_event_id,
+                v_loc->>'name',
+                (v_loc->>'latitude')::DOUBLE PRECISION,
+                (v_loc->>'longitude')::DOUBLE PRECISION,
+                (v_loc->>'is_primary')::BOOLEAN,
+                (v_loc->>'order_index')::INTEGER
+            )
+            RETURNING id INTO v_inserted_id;
+            v_location_ids := array_append(v_location_ids, v_inserted_id);
+        END LOOP;
+    END IF;
+
+    -- Replace categories
+    IF p_categories IS NOT NULL THEN
+        DELETE FROM public.event_categories WHERE event_id = p_event_id;
+        INSERT INTO public.event_categories (event_id, category_id)
+        SELECT p_event_id, (cat->>'category_id')::UUID
+        FROM jsonb_array_elements(p_categories) AS cat;
+    END IF;
+
+    -- Replace venue metadata
+    IF p_venue_metadata IS NOT NULL THEN
+        DELETE FROM public.venue_metadata WHERE event_id = p_event_id;
+        INSERT INTO public.venue_metadata (
+            event_id, price, language, health_requirements, wheelchair_access, accessible_restroom,
+            elevator_available, seating_available, captions_support, quiet_friendly
+        ) VALUES (
+            p_event_id,
+            p_venue_metadata->>'price',
+            p_venue_metadata->>'language',
+            p_venue_metadata->>'health_requirements',
+            (p_venue_metadata->>'wheelchair_access')::BOOLEAN,
+            (p_venue_metadata->>'accessible_restroom')::BOOLEAN,
+            (p_venue_metadata->>'elevator_available')::BOOLEAN,
+            (p_venue_metadata->>'seating_available')::BOOLEAN,
+            (p_venue_metadata->>'captions_support')::BOOLEAN,
+            (p_venue_metadata->>'quiet_friendly')::BOOLEAN
+        );
+    END IF;
+
+    -- Replace equipment
+    IF p_equipment IS NOT NULL THEN
+        DELETE FROM public.equipment_requirements WHERE event_id = p_event_id;
+        INSERT INTO public.equipment_requirements (event_id, item_name, is_required)
+        SELECT
+            p_event_id,
+            eq->>'item_name',
+            (eq->>'is_required')::BOOLEAN
+        FROM jsonb_array_elements(p_equipment) AS eq;
+    END IF;
+
+    -- Replace segments. NULL = leave existing segments untouched. An empty
+    -- array means "delete all segments". Any non-empty value triggers a
+    -- full replacement.
+    IF p_segments IS NOT NULL THEN
+        DELETE FROM public.event_segments WHERE event_id = p_event_id;
+
+        IF jsonb_array_length(p_segments) > 0 THEN
+            -- If locations were not replaced in this call, populate
+            -- v_location_ids from existing rows ordered (created_at,
+            -- order_index, id). app/repositories/event.py::get_event_locations
+            -- uses the same ORDER BY, so the client's `location_index`
+            -- references the same positional list it just read.
+            IF v_location_ids IS NULL THEN
+                SELECT array_agg(id ORDER BY created_at, order_index, id)
+                INTO v_location_ids
+                FROM public.event_locations
+                WHERE event_id = p_event_id;
+            END IF;
+
+            v_loc_count := COALESCE(array_length(v_location_ids, 1), 0);
+            IF v_loc_count = 0 THEN
+                RAISE EXCEPTION 'cannot insert segments: event has no locations'
+                    USING ERRCODE = 'check_violation';
+            END IF;
+
+            FOR v_seg IN SELECT * FROM jsonb_array_elements(p_segments) LOOP
+                v_loc_idx := (v_seg->>'location_index')::INT;
+                IF v_loc_idx < 0 OR v_loc_idx >= v_loc_count THEN
+                    RAISE EXCEPTION 'segment.location_index % out of range', v_loc_idx
+                        USING ERRCODE = 'check_violation';
+                END IF;
+                v_segment_location_id := v_location_ids[v_loc_idx + 1];
+
+                INSERT INTO public.event_segments (
+                    event_id, location_id, order_index, start_datetime, end_datetime, description
+                ) VALUES (
+                    p_event_id,
+                    v_segment_location_id,
+                    (v_seg->>'order_index')::INT,
+                    (v_seg->>'start_datetime')::TIMESTAMPTZ,
+                    (v_seg->>'end_datetime')::TIMESTAMPTZ,
+                    v_seg->>'description'
+                );
+            END LOOP;
+        END IF;
+    END IF;
+
+    -- Return updated event
+    SELECT to_jsonb(e) INTO v_result
+    FROM public.events e
+    WHERE e.id = p_event_id;
+
+    RETURN v_result;
+END;
+$$;

--- a/backend/sql/013_atomic_event_rpc_segments.sql
+++ b/backend/sql/013_atomic_event_rpc_segments.sql
@@ -25,6 +25,21 @@
 -- Run this in the Supabase SQL Editor AFTER 012_create_event_segments.sql.
 
 -- ----------------------------------------------------------------
+-- Drop the legacy 5-parameter signatures from migrations 009/010 first.
+-- `CREATE OR REPLACE FUNCTION` only replaces a function with an *identical*
+-- parameter list — adding p_segments produces a new overload alongside the
+-- old one, and PostgREST then errors out with PGRST203 on every RPC call
+-- ("could not choose the best candidate"). Dropping the legacy signatures
+-- here keeps the namespace unambiguous; the Python wrappers always send
+-- the full 6-key payload (p_segments included, possibly NULL).
+-- Safe to re-run: the IF EXISTS clauses turn this into a no-op when the
+-- legacy signatures are already gone.
+-- ----------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS public.create_event_atomic(jsonb, jsonb, jsonb, jsonb, jsonb);
+DROP FUNCTION IF EXISTS public.update_event_atomic(uuid, jsonb, jsonb, jsonb, jsonb, jsonb);
+
+-- ----------------------------------------------------------------
 -- create_event_atomic
 -- ----------------------------------------------------------------
 

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -113,6 +113,7 @@ def _create_published_event(user_id: str, cat_ids: list[str], mock_upload, **ove
 
 def _cleanup_event(event_id: str):
     """Delete an event and all related data."""
+    db.table("event_segments").delete().eq("event_id", event_id).execute()
     db.table("equipment_requirements").delete().eq("event_id", event_id).execute()
     db.table("venue_metadata").delete().eq("event_id", event_id).execute()
     db.table("event_categories").delete().eq("event_id", event_id).execute()
@@ -899,3 +900,409 @@ class TestClearAttendeeLimit:
 
         _cleanup_event(event_id)
         _cleanup_user(user["id"])
+
+
+# --- Itinerary segments (issue #149) ---------------------------------------
+
+def _two_locations_body(category_ids: list[str], **overrides) -> dict:
+    """Build a multi-location event body for segment tests.
+
+    Index 0 = primary stop, index 1 = secondary stop.
+    """
+    body = _valid_event_body(category_ids, **overrides)
+    body["locations"] = [
+        {"name": "Stop A", "latitude": 41.0, "longitude": 29.0, "is_primary": True, "order_index": 0},
+        {"name": "Stop B", "latitude": 41.1, "longitude": 29.1, "is_primary": False, "order_index": 1},
+    ]
+    return body
+
+
+def _seg_payload(*, location_index: int = 0, order_index: int = 0,
+                 start_offset_min: int = 30, duration_min: int = 30,
+                 description: str | None = None,
+                 anchor: datetime | None = None) -> dict:
+    """Build a segment payload anchored at the next-day event start."""
+    if anchor is None:
+        anchor = datetime.now(UTC) + timedelta(days=1)
+    start = anchor + timedelta(minutes=start_offset_min)
+    end = start + timedelta(minutes=duration_min)
+    return {
+        "location_index": location_index,
+        "order_index": order_index,
+        "start_datetime": start.isoformat(),
+        "end_datetime": end.isoformat(),
+        "description": description,
+    }
+
+
+class TestEventSegments:
+    """Create / read / update flows for itinerary segments."""
+
+    def test_create_event_with_segments(self):
+        user = _create_test_user("segcreate")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0,
+                         start_offset_min=30, duration_min=30, description="Welcome"),
+            _seg_payload(location_index=1, order_index=1,
+                         start_offset_min=60, duration_min=30, description="Move to Stop B"),
+        ])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 201, resp.json()
+
+        data = resp.json()
+        assert "segments" in data
+        assert len(data["segments"]) == 2
+        # Returned in order_index order
+        assert data["segments"][0]["order_index"] == 0
+        assert data["segments"][1]["order_index"] == 1
+        assert data["segments"][0]["description"] == "Welcome"
+        # location_id should resolve to a real location row on the event
+        location_ids = {loc["id"] for loc in data["locations"]}
+        for seg in data["segments"]:
+            assert seg["location_id"] in location_ids
+
+        _cleanup_event(data["id"])
+        _cleanup_user(user["id"])
+
+    def test_segment_location_index_matches_request_position_when_order_index_is_reversed(self):
+        # Pin the contract: location_index references the *position in the
+        # request's locations array*, not the position-after-sorting-by-order_index.
+        # If a host sends locations in non-monotonic order_index, segments
+        # must still resolve to the location at the same array position.
+        user = _create_test_user("seglocidx_pin")
+        cat_ids = _get_category_ids(1)
+        body = _valid_event_body(cat_ids)
+        # locations[0] has order_index=5, locations[1] has order_index=0
+        body["locations"] = [
+            {"name": "Position 0 (order_index 5)", "latitude": 41.0,
+             "longitude": 29.0, "is_primary": True,  "order_index": 5},
+            {"name": "Position 1 (order_index 0)", "latitude": 41.1,
+             "longitude": 29.1, "is_primary": False, "order_index": 0},
+        ]
+        # Segment 0 references location_index=0 → must point to "Position 0".
+        # Segment 1 references location_index=1 → must point to "Position 1".
+        body["segments"] = [
+            _seg_payload(location_index=0, order_index=0,
+                         start_offset_min=0,  duration_min=30),
+            _seg_payload(location_index=1, order_index=1,
+                         start_offset_min=60, duration_min=30),
+        ]
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 201, resp.json()
+
+        data = resp.json()
+        loc_by_id = {loc["id"]: loc for loc in data["locations"]}
+        # Pull segments back ordered by order_index to make assertions stable.
+        segs = sorted(data["segments"], key=lambda s: s["order_index"])
+        assert loc_by_id[segs[0]["location_id"]]["name"] == "Position 0 (order_index 5)"
+        assert loc_by_id[segs[1]["location_id"]]["name"] == "Position 1 (order_index 0)"
+
+        _cleanup_event(data["id"])
+        _cleanup_user(user["id"])
+
+    def test_create_event_without_segments_is_unaffected(self):
+        # Backward-compat: no segments provided → segments == []
+        user = _create_test_user("segnone")
+        cat_ids = _get_category_ids(1)
+        body = _valid_event_body(cat_ids)
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 201
+        assert resp.json().get("segments", []) == []
+
+        _cleanup_event(resp.json()["id"])
+        _cleanup_user(user["id"])
+
+    def test_segment_overlap_rejected(self):
+        user = _create_test_user("segoverlap")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=60),
+            _seg_payload(location_index=1, order_index=1, start_offset_min=30, duration_min=60),
+        ])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 400
+        assert "overlap" in resp.json()["detail"].lower()
+
+        _cleanup_user(user["id"])
+
+    def test_segment_inverted_time_rejected(self):
+        user = _create_test_user("seginvert")
+        cat_ids = _get_category_ids(1)
+        anchor = datetime.now(UTC) + timedelta(days=1)
+        bad = {
+            "location_index": 0,
+            "order_index": 0,
+            # end before start
+            "start_datetime": (anchor + timedelta(hours=1)).isoformat(),
+            "end_datetime": (anchor + timedelta(minutes=30)).isoformat(),
+            "description": None,
+        }
+        body = _two_locations_body(cat_ids, segments=[bad])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 400
+        assert "after start_datetime" in resp.json()["detail"]
+
+        _cleanup_user(user["id"])
+
+    def test_segment_outside_event_window_rejected(self):
+        user = _create_test_user("segwindow")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            # Event is 2h long; this segment lands 5h after start.
+            _seg_payload(location_index=0, order_index=0,
+                         start_offset_min=300, duration_min=30),
+        ])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 400
+        assert "within event" in resp.json()["detail"]
+
+        _cleanup_user(user["id"])
+
+    def test_segment_invalid_location_index(self):
+        user = _create_test_user("seglocidx")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            # Only 2 locations → location_index 5 is out of range.
+            _seg_payload(location_index=5, order_index=0),
+        ])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 400
+        assert "out of range" in resp.json()["detail"]
+
+        _cleanup_user(user["id"])
+
+    def test_segment_non_contiguous_order_rejected(self):
+        user = _create_test_user("segorder")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+            _seg_payload(location_index=1, order_index=2, start_offset_min=60, duration_min=30),
+        ])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 400
+        assert "contiguous order_index" in resp.json()["detail"]
+
+        _cleanup_user(user["id"])
+
+    def test_segment_duplicate_order_index_rejected(self):
+        user = _create_test_user("segduplo")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+            _seg_payload(location_index=1, order_index=0, start_offset_min=60, duration_min=30),
+        ])
+
+        resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert resp.status_code == 400
+        assert "contiguous order_index" in resp.json()["detail"]
+
+        _cleanup_user(user["id"])
+
+    def test_update_replaces_segments(self):
+        user = _create_test_user("segupd")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+            _seg_payload(location_index=1, order_index=1, start_offset_min=60, duration_min=30),
+        ])
+        create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert create_resp.status_code == 201
+        event_id = create_resp.json()["id"]
+        assert len(create_resp.json()["segments"]) == 2
+
+        # PUT with a single segment should replace the existing two
+        new_segs = [
+            _seg_payload(location_index=0, order_index=0,
+                         start_offset_min=15, duration_min=15, description="Just one"),
+        ]
+        update_resp = client.put(
+            f"/events/{event_id}",
+            json={"segments": new_segs},
+            headers=_auth_header(user["id"]),
+        )
+        assert update_resp.status_code == 200, update_resp.json()
+        assert len(update_resp.json()["segments"]) == 1
+        assert update_resp.json()["segments"][0]["description"] == "Just one"
+
+        _cleanup_event(event_id)
+        _cleanup_user(user["id"])
+
+    def test_update_without_segments_leaves_them_untouched(self):
+        # PUT with no `segments` key → existing segments preserved.
+        user = _create_test_user("segleave")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+        ])
+        create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        event_id = create_resp.json()["id"]
+
+        update_resp = client.put(
+            f"/events/{event_id}",
+            json={"title": "New title"},
+            headers=_auth_header(user["id"]),
+        )
+        assert update_resp.status_code == 200
+        assert update_resp.json()["title"] == "New title"
+        assert len(update_resp.json()["segments"]) == 1
+
+        _cleanup_event(event_id)
+        _cleanup_user(user["id"])
+
+    def test_update_locations_without_segments_when_segments_exist_rejected(self):
+        # Replacing locations CASCADEs through segments — must reject silent loss.
+        user = _create_test_user("seglocrep")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0, duration_min=30),
+        ])
+        create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        event_id = create_resp.json()["id"]
+
+        new_locs = [
+            {"name": "New stop", "latitude": 42.0, "longitude": 30.0, "is_primary": True, "order_index": 0},
+        ]
+        resp = client.put(
+            f"/events/{event_id}",
+            json={"locations": new_locs},
+            headers=_auth_header(user["id"]),
+        )
+        assert resp.status_code == 400
+        assert "clears existing segments" in resp.json()["detail"]
+
+        _cleanup_event(event_id)
+        _cleanup_user(user["id"])
+
+    def test_update_locations_with_explicit_empty_segments_clears_them(self):
+        user = _create_test_user("segclear")
+        cat_ids = _get_category_ids(1)
+        body = _two_locations_body(cat_ids, segments=[
+            _seg_payload(location_index=0, order_index=0, start_offset_min=0, duration_min=30),
+        ])
+        create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        event_id = create_resp.json()["id"]
+
+        new_locs = [
+            {"name": "New stop", "latitude": 42.0, "longitude": 30.0, "is_primary": True, "order_index": 0},
+        ]
+        resp = client.put(
+            f"/events/{event_id}",
+            json={"locations": new_locs, "segments": []},
+            headers=_auth_header(user["id"]),
+        )
+        assert resp.status_code == 200, resp.json()
+        assert resp.json()["segments"] == []
+
+        _cleanup_event(event_id)
+        _cleanup_user(user["id"])
+
+    def test_update_segments_after_event_start_rejected(self):
+        # Insert an event whose start is in the past, then try to PUT segments.
+        user = _create_test_user("segstarted")
+        event_data = {
+            "host_id": user["id"],
+            "title": "In-flight event",
+            "description": "Already running",
+            "start_datetime": (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+            "end_datetime": (datetime.now(UTC) + timedelta(hours=2)).isoformat(),
+            "visibility": "public",
+            "status": "published",
+        }
+        result = db.table("events").insert(event_data).execute()
+        event_id = result.data[0]["id"]
+        db.table("event_locations").insert({
+            "event_id": event_id, "name": "Stop A", "latitude": 41.0, "longitude": 29.0,
+            "is_primary": True, "order_index": 0,
+        }).execute()
+
+        anchor = datetime.now(UTC) - timedelta(minutes=30)
+        resp = client.put(
+            f"/events/{event_id}",
+            json={"segments": [_seg_payload(
+                location_index=0, order_index=0, anchor=anchor,
+                start_offset_min=0, duration_min=30,
+            )]},
+            headers=_auth_header(user["id"]),
+        )
+        assert resp.status_code == 400
+        assert "segments after event has started" in resp.json()["detail"]
+
+        _cleanup_event(event_id)
+        _cleanup_user(user["id"])
+
+
+# --- Duplicate event detection (FRS-2: primary location only) --------------
+
+class TestDuplicateEventDetection:
+    """Issue #149 FRS-2: identical title + start_datetime + primary location for the same host is rejected."""
+
+    def test_duplicate_with_matching_primary_rejected(self):
+        user = _create_test_user("dupprim")
+        cat_ids = _get_category_ids(1)
+        body = _valid_event_body(cat_ids)
+
+        first = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert first.status_code == 201
+        first_id = first.json()["id"]
+
+        # Same body, same host → conflict on title + start + primary location
+        second = client.post("/events", json=body, headers=_auth_header(user["id"]))
+        assert second.status_code == 409
+        assert "primary location" in second.json()["detail"]
+
+        _cleanup_event(first_id)
+        _cleanup_user(user["id"])
+
+    def test_duplicate_with_only_secondary_match_allowed(self):
+        # Both events share title + start_datetime + a stop name, but the
+        # collision is only on the *secondary* stop. Issue spec scopes
+        # duplicate detection to primary, so this must be allowed.
+        user = _create_test_user("dupsec")
+        cat_ids = _get_category_ids(1)
+
+        first_body = _valid_event_body(cat_ids)
+        first_body["locations"] = [
+            {"name": "Primary One", "latitude": 41.0, "longitude": 29.0, "is_primary": True, "order_index": 0},
+            {"name": "Shared Stop", "latitude": 41.1, "longitude": 29.1, "is_primary": False, "order_index": 1},
+        ]
+        first_resp = client.post("/events", json=first_body, headers=_auth_header(user["id"]))
+        assert first_resp.status_code == 201
+
+        second_body = dict(first_body)
+        # Different primary, same secondary "Shared Stop"
+        second_body["locations"] = [
+            {"name": "Primary Two", "latitude": 42.0, "longitude": 30.0, "is_primary": True, "order_index": 0},
+            {"name": "Shared Stop", "latitude": 41.1, "longitude": 29.1, "is_primary": False, "order_index": 1},
+        ]
+        second_resp = client.post("/events", json=second_body, headers=_auth_header(user["id"]))
+        assert second_resp.status_code == 201, second_resp.json()
+
+        _cleanup_event(first_resp.json()["id"])
+        _cleanup_event(second_resp.json()["id"])
+        _cleanup_user(user["id"])
+
+    def test_duplicate_for_different_hosts_allowed(self):
+        # Same title, time, primary — but different hosts: not a duplicate.
+        host_a = _create_test_user("duphostA")
+        host_b = _create_test_user("duphostB")
+        cat_ids = _get_category_ids(1)
+        body = _valid_event_body(cat_ids)
+
+        first = client.post("/events", json=body, headers=_auth_header(host_a["id"]))
+        second = client.post("/events", json=body, headers=_auth_header(host_b["id"]))
+        assert first.status_code == 201
+        assert second.status_code == 201
+
+        _cleanup_event(first.json()["id"])
+        _cleanup_event(second.json()["id"])
+        _cleanup_user(host_a["id"])
+        _cleanup_user(host_b["id"])

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1017,12 +1017,18 @@ class TestEventSegments:
         _cleanup_user(user["id"])
 
     def test_segment_overlap_rejected(self):
+        # Build body first so segments can anchor to the event's actual
+        # start_datetime — Python evaluates kwargs before the call, which
+        # would otherwise put each segment's anchor a few microseconds
+        # *before* the event start and trip the window check first.
         user = _create_test_user("segoverlap")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=60),
-            _seg_payload(location_index=1, order_index=1, start_offset_min=30, duration_min=60),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0,  duration_min=60),
+            _seg_payload(anchor=event_start, location_index=1, order_index=1, start_offset_min=30, duration_min=60),
+        ]
 
         resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         assert resp.status_code == 400
@@ -1082,10 +1088,12 @@ class TestEventSegments:
     def test_segment_non_contiguous_order_rejected(self):
         user = _create_test_user("segorder")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
-            _seg_payload(location_index=1, order_index=2, start_offset_min=60, duration_min=30),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+            _seg_payload(anchor=event_start, location_index=1, order_index=2, start_offset_min=60, duration_min=30),
+        ]
 
         resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         assert resp.status_code == 400
@@ -1096,10 +1104,12 @@ class TestEventSegments:
     def test_segment_duplicate_order_index_rejected(self):
         user = _create_test_user("segduplo")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
-            _seg_payload(location_index=1, order_index=0, start_offset_min=60, duration_min=30),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+            _seg_payload(anchor=event_start, location_index=1, order_index=0, start_offset_min=60, duration_min=30),
+        ]
 
         resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         assert resp.status_code == 400
@@ -1110,10 +1120,12 @@ class TestEventSegments:
     def test_update_replaces_segments(self):
         user = _create_test_user("segupd")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
-            _seg_payload(location_index=1, order_index=1, start_offset_min=60, duration_min=30),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+            _seg_payload(anchor=event_start, location_index=1, order_index=1, start_offset_min=60, duration_min=30),
+        ]
         create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         assert create_resp.status_code == 201
         event_id = create_resp.json()["id"]
@@ -1121,7 +1133,7 @@ class TestEventSegments:
 
         # PUT with a single segment should replace the existing two
         new_segs = [
-            _seg_payload(location_index=0, order_index=0,
+            _seg_payload(anchor=event_start, location_index=0, order_index=0,
                          start_offset_min=15, duration_min=15, description="Just one"),
         ]
         update_resp = client.put(
@@ -1140,9 +1152,11 @@ class TestEventSegments:
         # PUT with no `segments` key → existing segments preserved.
         user = _create_test_user("segleave")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0,  duration_min=30),
+        ]
         create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         event_id = create_resp.json()["id"]
 
@@ -1162,9 +1176,11 @@ class TestEventSegments:
         # Replacing locations CASCADEs through segments — must reject silent loss.
         user = _create_test_user("seglocrep")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0, duration_min=30),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0, duration_min=30),
+        ]
         create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         event_id = create_resp.json()["id"]
 
@@ -1185,9 +1201,11 @@ class TestEventSegments:
     def test_update_locations_with_explicit_empty_segments_clears_them(self):
         user = _create_test_user("segclear")
         cat_ids = _get_category_ids(1)
-        body = _two_locations_body(cat_ids, segments=[
-            _seg_payload(location_index=0, order_index=0, start_offset_min=0, duration_min=30),
-        ])
+        body = _two_locations_body(cat_ids)
+        event_start = datetime.fromisoformat(body["start_datetime"])
+        body["segments"] = [
+            _seg_payload(anchor=event_start, location_index=0, order_index=0, start_offset_min=0, duration_min=30),
+        ]
         create_resp = client.post("/events", json=body, headers=_auth_header(user["id"]))
         event_id = create_resp.json()["id"]
 

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -546,3 +546,61 @@ class TestAccessDecision:
         )
         assert resp.status_code == 400
         assert "resolved" in resp.json()["detail"].lower()
+
+
+class TestAccessDecisionNotifications:
+    """Issue #149: rejection of an access request must persist an
+    `access_rejected` notification for the requester."""
+
+    def test_rejection_notifies_requester(self):
+        host = _create_test_user()
+        user = _create_test_user()
+        event = _create_private_published_event(host["id"])
+
+        req_resp = client.post(
+            f"/events/{event['id']}/access-requests",
+            headers=_auth_header(user["id"]),
+        )
+        request_id = req_resp.json()["id"]
+
+        decide_resp = client.patch(
+            f"/events/{event['id']}/access-requests/{request_id}",
+            json={"status": "rejected"},
+            headers=_auth_header(host["id"]),
+        )
+        assert decide_resp.status_code == 200
+
+        notif_resp = client.get("/notifications", headers=_auth_header(user["id"]))
+        assert notif_resp.status_code == 200
+        notifications = notif_resp.json()["items"]
+        rejected = [n for n in notifications if n["type"] == "access_rejected"]
+        assert len(rejected) == 1
+        row = rejected[0]
+        assert row["event_id"] == event["id"]
+        assert event["title"] in row["message"]
+        assert row["is_read"] is False
+
+    def test_approval_does_not_emit_access_rejected(self):
+        # Pin exclusivity — approving an access request must not emit
+        # an access_rejected row.
+        host = _create_test_user()
+        user = _create_test_user()
+        event = _create_private_published_event(host["id"])
+
+        req_resp = client.post(
+            f"/events/{event['id']}/access-requests",
+            headers=_auth_header(user["id"]),
+        )
+        request_id = req_resp.json()["id"]
+
+        client.patch(
+            f"/events/{event['id']}/access-requests/{request_id}",
+            json={"status": "approved"},
+            headers=_auth_header(host["id"]),
+        )
+
+        notif_resp = client.get("/notifications", headers=_auth_header(user["id"]))
+        notifications = notif_resp.json()["items"]
+        assert all(n["type"] != "access_rejected" for n in notifications)
+        # Sanity: approval *does* notify with access_approved.
+        assert any(n["type"] == "access_approved" for n in notifications)

--- a/backend/tests/test_notification_emitter.py
+++ b/backend/tests/test_notification_emitter.py
@@ -195,3 +195,94 @@ class TestCancelNotification:
         assert len(end_notifs) == 0
 
         _cleanup_notifications(user["id"])
+
+
+# --- Delete Notification Tests (issue #149) ---
+
+class TestDeleteNotification:
+    """delete_event must emit `event_deleted` to bookmarkers and going attendees
+    *before* the event row is removed. notifications.event_id is ON DELETE
+    SET NULL, so the rows survive with event_id cleared.
+    """
+
+    def _force_terminal(self, event_id: str, status_str: str = "cancelled") -> None:
+        """Bypass the host-driven cancel route to set up a deletable event quickly."""
+        db.table("events").update({"status": status_str}).eq("id", event_id).execute()
+
+    def test_delete_notifies_going_attendee(self):
+        host = _create_test_user()
+        attendee = _create_test_user()
+        event = _create_published_event(host["id"])
+        event_id = event["id"]
+
+        _add_attendance(attendee["id"], event_id, "going")
+        self._force_terminal(event_id, "cancelled")
+        # Wipe the cancel notification so we can inspect the delete one alone.
+        _cleanup_notifications(attendee["id"])
+
+        del_resp = client.delete(f"/events/{event_id}", headers=_auth_header(host["id"]))
+        assert del_resp.status_code == 200, del_resp.json()
+
+        notifications = _get_notifications(attendee["id"])
+        deleted = [n for n in notifications if n["type"] == "event_deleted"]
+        assert len(deleted) == 1
+        # FK is SET NULL after delete — the notification stays, event_id is None.
+        assert deleted[0].get("event_id") is None
+
+        _cleanup_notifications(attendee["id"])
+
+    def test_delete_notifies_bookmarker(self):
+        host = _create_test_user()
+        bookmarker = _create_test_user()
+        event = _create_published_event(host["id"])
+        event_id = event["id"]
+
+        _add_bookmark(bookmarker["id"], event_id)
+        self._force_terminal(event_id, "ended")  # ended path: no cancel notification
+
+        del_resp = client.delete(f"/events/{event_id}", headers=_auth_header(host["id"]))
+        assert del_resp.status_code == 200
+
+        notifications = _get_notifications(bookmarker["id"])
+        deleted = [n for n in notifications if n["type"] == "event_deleted"]
+        assert len(deleted) == 1
+        assert deleted[0].get("event_id") is None
+
+        _cleanup_notifications(bookmarker["id"])
+
+    def test_delete_does_not_notify_host(self):
+        host = _create_test_user()
+        event = _create_published_event(host["id"])
+        event_id = event["id"]
+
+        _add_bookmark(host["id"], event_id)  # host bookmarking own event — edge case
+        self._force_terminal(event_id, "ended")
+
+        del_resp = client.delete(f"/events/{event_id}", headers=_auth_header(host["id"]))
+        assert del_resp.status_code == 200
+
+        host_notifications = _get_notifications(host["id"])
+        deleted = [n for n in host_notifications if n["type"] == "event_deleted"]
+        assert len(deleted) == 0  # host is excluded from emit_event_notification
+
+        _cleanup_notifications(host["id"])
+
+    def test_delete_does_not_notify_interested_only_user(self):
+        # Only `going` attendees and bookmarkers receive event_deleted —
+        # `interested` is intentionally not in the affected set.
+        host = _create_test_user()
+        interested = _create_test_user()
+        event = _create_published_event(host["id"])
+        event_id = event["id"]
+
+        _add_attendance(interested["id"], event_id, "interested")
+        self._force_terminal(event_id, "ended")
+
+        del_resp = client.delete(f"/events/{event_id}", headers=_auth_header(host["id"]))
+        assert del_resp.status_code == 200
+
+        notifications = _get_notifications(interested["id"])
+        deleted = [n for n in notifications if n["type"] == "event_deleted"]
+        assert len(deleted) == 0
+
+        _cleanup_notifications(interested["id"])

--- a/backend/tests/test_segments_unit.py
+++ b/backend/tests/test_segments_unit.py
@@ -1,0 +1,868 @@
+"""Phase 1 unit tests for itinerary segments — schema validation only.
+
+These tests cover the Pydantic models added in app/models/event.py and the
+repository wrapper signatures that pass `p_segments` to the atomic RPCs.
+They run as part of the `unit-fast` CI shard (`tests/test_*_unit.py`) and
+do not touch the database.
+
+Service-level validators (overlap / window / order) and end-to-end create/
+update flows are covered by later phases.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.models.event import (
+    EventCreateRequest,
+    EventDetailResponse,
+    EventUpdateRequest,
+    LocationRequest,
+    SegmentRequest,
+    SegmentResponse,
+)
+from app.repositories import event as event_repo
+from app.services.event import _build_segment_rows, validate_segments
+
+# --- SegmentRequest schema ---------------------------------------------------
+
+class TestSegmentRequestSchema:
+    def _payload(self, **overrides):
+        base = {
+            "location_index": 0,
+            "order_index": 0,
+            "start_datetime": datetime.now(UTC) + timedelta(hours=1),
+            "end_datetime": datetime.now(UTC) + timedelta(hours=2),
+            "description": "Opening session",
+        }
+        base.update(overrides)
+        return base
+
+    def test_minimal_payload_parses(self):
+        seg = SegmentRequest(**self._payload(description=None))
+        assert seg.location_index == 0
+        assert seg.order_index == 0
+        assert seg.description is None
+
+    def test_negative_location_index_rejected(self):
+        with pytest.raises(ValidationError):
+            SegmentRequest(**self._payload(location_index=-1))
+
+    def test_negative_order_index_rejected(self):
+        with pytest.raises(ValidationError):
+            SegmentRequest(**self._payload(order_index=-1))
+
+    def test_description_length_capped(self):
+        with pytest.raises(ValidationError):
+            SegmentRequest(**self._payload(description="x" * 1001))
+
+    def test_description_at_limit_accepted(self):
+        seg = SegmentRequest(**self._payload(description="x" * 1000))
+        assert len(seg.description) == 1000
+
+    def test_missing_required_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            SegmentRequest(location_index=0, order_index=0)
+
+
+# --- SegmentResponse schema --------------------------------------------------
+
+class TestSegmentResponseSchema:
+    def test_response_round_trips_uuids(self):
+        sid = uuid4()
+        lid = uuid4()
+        now = datetime.now(UTC)
+        resp = SegmentResponse(
+            id=sid,
+            location_id=lid,
+            order_index=2,
+            start_datetime=now,
+            end_datetime=now + timedelta(hours=1),
+            description=None,
+        )
+        assert resp.id == sid
+        assert resp.location_id == lid
+        assert resp.order_index == 2
+
+    def test_description_optional(self):
+        resp = SegmentResponse(
+            id=uuid4(),
+            location_id=uuid4(),
+            order_index=0,
+            start_datetime=datetime.now(UTC),
+            end_datetime=datetime.now(UTC) + timedelta(hours=1),
+        )
+        assert resp.description is None
+
+
+# --- EventCreate / EventUpdate accept segments -------------------------------
+
+def _location() -> LocationRequest:
+    return LocationRequest(
+        name="Main hall", latitude=41.0, longitude=29.0, is_primary=True, order_index=0,
+    )
+
+
+def _segment(**overrides) -> SegmentRequest:
+    base = {
+        "location_index": 0,
+        "order_index": 0,
+        "start_datetime": datetime.now(UTC) + timedelta(hours=1),
+        "end_datetime": datetime.now(UTC) + timedelta(hours=2),
+        "description": "Welcome",
+    }
+    base.update(overrides)
+    return SegmentRequest(**base)
+
+
+class TestEventCreateAcceptsSegments:
+    def _payload(self, segments):
+        return EventCreateRequest(
+            title="Itinerary event",
+            description="Multi-stop event",
+            start_datetime=datetime.now(UTC) + timedelta(hours=1),
+            end_datetime=datetime.now(UTC) + timedelta(hours=4),
+            visibility="public",
+            is_age_restricted=False,
+            attendee_limit=None,
+            status="draft",
+            category_ids=[uuid4()],
+            locations=[_location()],
+            segments=segments,
+        )
+
+    def test_segments_default_to_none(self):
+        body = EventCreateRequest(
+            title="No segments",
+            description="ok",
+            start_datetime=datetime.now(UTC) + timedelta(hours=1),
+            end_datetime=datetime.now(UTC) + timedelta(hours=2),
+            category_ids=[uuid4()],
+            locations=[_location()],
+        )
+        assert body.segments is None
+
+    def test_empty_segments_list_accepted(self):
+        body = self._payload(segments=[])
+        assert body.segments == []
+
+    def test_segments_attached(self):
+        body = self._payload(segments=[_segment()])
+        assert len(body.segments) == 1
+        assert body.segments[0].location_index == 0
+
+
+class TestEventUpdateAcceptsSegments:
+    def test_segments_default_to_none(self):
+        body = EventUpdateRequest()
+        assert body.segments is None
+
+    def test_segments_attached(self):
+        body = EventUpdateRequest(segments=[_segment(), _segment(order_index=1, start_datetime=datetime.now(UTC) + timedelta(hours=2, minutes=1), end_datetime=datetime.now(UTC) + timedelta(hours=3))])
+        assert len(body.segments) == 2
+
+
+# --- EventDetailResponse exposes segments ------------------------------------
+
+class TestEventDetailResponseSegments:
+    def test_segments_default_empty(self):
+        now = datetime.now(UTC)
+        detail = EventDetailResponse(
+            id=uuid4(),
+            host_id=uuid4(),
+            title="t",
+            description="d",
+            start_datetime=now,
+            end_datetime=now + timedelta(hours=1),
+            visibility="public",
+            is_age_restricted=False,
+            attendee_limit=None,
+            attendee_count=0,
+            status="draft",
+            created_at=now,
+            updated_at=now,
+        )
+        assert detail.segments == []
+
+
+# --- Repository RPC wrappers pass `p_segments` -------------------------------
+
+class TestRepoCreateEventAtomicPassesSegments:
+    def _exec_db(self):
+        db = MagicMock()
+        db.rpc.return_value.execute.return_value.data = {"id": str(uuid4())}
+        return db
+
+    def test_segments_param_forwarded(self):
+        db = self._exec_db()
+        seg_rows = [{
+            "location_index": 0,
+            "order_index": 0,
+            "start_datetime": "2030-01-01T10:00:00+00:00",
+            "end_datetime": "2030-01-01T11:00:00+00:00",
+            "description": None,
+        }]
+        event_repo.create_event_atomic(
+            db,
+            event_data={"title": "x"},
+            locations=[{"name": "L1"}],
+            category_ids=["cat-id"],
+            segments=seg_rows,
+        )
+        args, _ = db.rpc.call_args
+        assert args[0] == "create_event_atomic"
+        params = args[1]
+        assert params["p_segments"] == seg_rows
+
+    def test_segments_default_none(self):
+        db = self._exec_db()
+        event_repo.create_event_atomic(
+            db,
+            event_data={"title": "x"},
+            locations=[{"name": "L1"}],
+            category_ids=["cat-id"],
+        )
+        params = db.rpc.call_args[0][1]
+        assert params["p_segments"] is None
+
+
+class TestRepoUpdateEventAtomicPassesSegments:
+    def _exec_db(self):
+        db = MagicMock()
+        db.rpc.return_value.execute.return_value.data = {"id": str(uuid4())}
+        return db
+
+    def test_segments_param_forwarded(self):
+        db = self._exec_db()
+        seg_rows = [{"location_index": 1, "order_index": 0}]
+        event_repo.update_event_atomic(
+            db,
+            event_id=str(uuid4()),
+            segments=seg_rows,
+        )
+        args, _ = db.rpc.call_args
+        assert args[0] == "update_event_atomic"
+        params = args[1]
+        assert params["p_segments"] == seg_rows
+
+    def test_segments_default_none_means_untouched(self):
+        db = self._exec_db()
+        event_repo.update_event_atomic(db, event_id=str(uuid4()))
+        params = db.rpc.call_args[0][1]
+        # NULL → leave existing segments alone (matches RPC contract).
+        assert params["p_segments"] is None
+
+    def test_segments_empty_array_means_clear_all(self):
+        db = self._exec_db()
+        event_repo.update_event_atomic(db, event_id=str(uuid4()), segments=[])
+        params = db.rpc.call_args[0][1]
+        # [] is distinct from None — RPC reads it as "delete every segment".
+        assert params["p_segments"] == []
+
+
+# --- Repository read helper --------------------------------------------------
+
+class TestGetEventSegments:
+    def test_orders_by_order_index_and_returns_rows(self):
+        db = MagicMock()
+        rows = [
+            {"id": str(uuid4()), "order_index": 0},
+            {"id": str(uuid4()), "order_index": 1},
+        ]
+        chain = db.table.return_value.select.return_value.eq.return_value.order.return_value.execute
+        chain.return_value.data = rows
+
+        result = event_repo.get_event_segments(db, "event-id")
+
+        db.table.assert_called_with("event_segments")
+        assert result == rows
+
+    def test_returns_empty_list_when_none(self):
+        db = MagicMock()
+        chain = db.table.return_value.select.return_value.eq.return_value.order.return_value.execute
+        chain.return_value.data = None
+
+        assert event_repo.get_event_segments(db, "event-id") == []
+
+
+# --- validate_segments (service-layer) --------------------------------------
+
+def _seg(
+    *,
+    location_index: int = 0,
+    order_index: int = 0,
+    start_offset_min: int = 60,
+    duration_min: int = 30,
+    description: str | None = None,
+) -> SegmentRequest:
+    base = datetime(2030, 1, 1, 10, 0, 0, tzinfo=UTC)
+    start = base + timedelta(minutes=start_offset_min)
+    end = start + timedelta(minutes=duration_min)
+    return SegmentRequest(
+        location_index=location_index,
+        order_index=order_index,
+        start_datetime=start,
+        end_datetime=end,
+        description=description,
+    )
+
+
+_EVENT_START = datetime(2030, 1, 1, 10, 0, 0, tzinfo=UTC)
+_EVENT_END = datetime(2030, 1, 1, 14, 0, 0, tzinfo=UTC)
+
+
+class TestValidateSegments:
+    def test_none_is_noop(self):
+        validate_segments(None, location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+
+    def test_empty_list_is_noop(self):
+        validate_segments([], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+
+    def test_single_valid_segment_passes(self):
+        validate_segments(
+            [_seg()], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END,
+        )
+
+    def test_two_back_to_back_segments_pass(self):
+        # 10:30–11:00 then 11:00–11:30 — non-overlapping, contiguous order
+        segments = [
+            _seg(order_index=0, start_offset_min=30, duration_min=30),
+            _seg(order_index=1, start_offset_min=60, duration_min=30),
+        ]
+        validate_segments(
+            segments, location_count=1, event_start=_EVENT_START, event_end=_EVENT_END,
+        )
+
+    def test_location_index_out_of_range(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_segments(
+                [_seg(location_index=2)],
+                location_count=1,
+                event_start=_EVENT_START,
+                event_end=_EVENT_END,
+            )
+        assert exc.value.status_code == 400
+        assert "out of range" in exc.value.detail
+
+    def test_location_index_at_count_rejected(self):
+        # 0 < count == 1 means valid index is only 0
+        with pytest.raises(HTTPException):
+            validate_segments(
+                [_seg(location_index=1)],
+                location_count=1,
+                event_start=_EVENT_START,
+                event_end=_EVENT_END,
+            )
+
+    def test_inverted_time_rejected(self):
+        bad = SegmentRequest(
+            location_index=0,
+            order_index=0,
+            start_datetime=_EVENT_START + timedelta(hours=2),
+            end_datetime=_EVENT_START + timedelta(hours=1),
+        )
+        with pytest.raises(HTTPException) as exc:
+            validate_segments([bad], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+        assert "after start_datetime" in exc.value.detail
+
+    def test_zero_duration_rejected(self):
+        same = _EVENT_START + timedelta(hours=1)
+        bad = SegmentRequest(
+            location_index=0,
+            order_index=0,
+            start_datetime=same,
+            end_datetime=same,
+        )
+        with pytest.raises(HTTPException):
+            validate_segments([bad], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+
+    def test_naive_datetime_rejected(self):
+        naive_start = datetime(2030, 1, 1, 11, 0, 0)
+        bad = SegmentRequest(
+            location_index=0,
+            order_index=0,
+            start_datetime=naive_start,
+            end_datetime=naive_start + timedelta(hours=1),
+        )
+        with pytest.raises(HTTPException) as exc:
+            validate_segments([bad], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+        assert "timezone" in exc.value.detail
+
+    def test_segment_starts_before_event(self):
+        before = SegmentRequest(
+            location_index=0,
+            order_index=0,
+            start_datetime=_EVENT_START - timedelta(minutes=30),
+            end_datetime=_EVENT_START + timedelta(minutes=30),
+        )
+        with pytest.raises(HTTPException) as exc:
+            validate_segments([before], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+        assert "within event" in exc.value.detail
+
+    def test_segment_ends_after_event(self):
+        after = SegmentRequest(
+            location_index=0,
+            order_index=0,
+            start_datetime=_EVENT_END - timedelta(minutes=30),
+            end_datetime=_EVENT_END + timedelta(minutes=30),
+        )
+        with pytest.raises(HTTPException):
+            validate_segments([after], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+
+    def test_overlapping_segments_rejected(self):
+        # 10:00–11:00 then 10:30–11:30 — overlap
+        a = _seg(order_index=0, start_offset_min=0, duration_min=60)
+        b = _seg(order_index=1, start_offset_min=30, duration_min=60)
+        with pytest.raises(HTTPException) as exc:
+            validate_segments([a, b], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+        assert "overlap" in exc.value.detail
+
+    def test_overlap_caught_when_segments_passed_unsorted(self):
+        # Same as above but reverse order in the input list — validator must
+        # sort by order_index before checking overlaps.
+        a = _seg(order_index=0, start_offset_min=0, duration_min=60)
+        b = _seg(order_index=1, start_offset_min=30, duration_min=60)
+        with pytest.raises(HTTPException):
+            validate_segments([b, a], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+
+    def test_non_contiguous_order_index_rejected(self):
+        # 0, 2 — skipping 1
+        a = _seg(order_index=0, start_offset_min=0, duration_min=30)
+        b = _seg(order_index=2, start_offset_min=60, duration_min=30)
+        with pytest.raises(HTTPException) as exc:
+            validate_segments([a, b], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+        assert "contiguous order_index" in exc.value.detail
+
+    def test_duplicate_order_index_rejected(self):
+        a = _seg(order_index=0, start_offset_min=0, duration_min=30)
+        b = _seg(order_index=0, start_offset_min=60, duration_min=30)
+        with pytest.raises(HTTPException) as exc:
+            validate_segments([a, b], location_count=1, event_start=_EVENT_START, event_end=_EVENT_END)
+        assert "contiguous order_index" in exc.value.detail
+
+    def test_overlap_rule_is_location_independent(self):
+        # Issue spec says "no time overlaps" — the rule is global, not per-location.
+        # Two segments at different stops still cannot overlap in time.
+        a = _seg(location_index=0, order_index=0, start_offset_min=0, duration_min=60)
+        b = _seg(location_index=1, order_index=1, start_offset_min=30, duration_min=60)
+        with pytest.raises(HTTPException):
+            validate_segments([a, b], location_count=2, event_start=_EVENT_START, event_end=_EVENT_END)
+
+
+# --- _build_segment_rows -----------------------------------------------------
+
+class TestBuildSegmentRows:
+    def test_none_returns_none(self):
+        assert _build_segment_rows(None) is None
+
+    def test_empty_returns_empty_list(self):
+        assert _build_segment_rows([]) == []
+
+    def test_serialises_isoformat_and_description(self):
+        seg = _seg(description="Opening")
+        rows = _build_segment_rows([seg])
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["location_index"] == 0
+        assert row["order_index"] == 0
+        # ISO format strings only — RPC casts these to TIMESTAMPTZ
+        assert isinstance(row["start_datetime"], str)
+        assert "T" in row["start_datetime"]
+        assert row["description"] == "Opening"
+
+    def test_description_none_preserved(self):
+        rows = _build_segment_rows([_seg(description=None)])
+        assert rows[0]["description"] is None
+
+
+# --- update_event segment guards ---------------------------------------------
+
+class TestUpdateEventSegmentGuards:
+    """Unit-level coverage of the new branches in update_event.
+
+    All DB calls are mocked — these tests run in the unit-fast shard.
+    """
+
+    def _make_event(self, *, started: bool, locations_count: int = 1, status_str: str = "published"):
+        from app.repositories import event as repo
+        from app.services import event as svc
+
+        host_id = str(uuid4())
+        event_id = str(uuid4())
+        # event start must be in the past for `started=True`
+        event_start = (
+            datetime.now(UTC) - timedelta(hours=1) if started
+            else datetime.now(UTC) + timedelta(hours=2)
+        )
+        event_row = {
+            "id": event_id,
+            "host_id": host_id,
+            "title": "T",
+            "description": "D",
+            "start_datetime": event_start.isoformat(),
+            "end_datetime": (event_start + timedelta(hours=4)).isoformat(),
+            "visibility": "public",
+            "is_age_restricted": False,
+            "attendee_limit": None,
+            "attendee_count": 0,
+            "status": status_str,
+            "created_at": datetime.now(UTC).isoformat(),
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        location_rows = [{"id": str(uuid4()), "order_index": i} for i in range(locations_count)]
+        return host_id, event_id, event_row, location_rows, repo, svc
+
+    def test_segments_after_start_rejected(self, monkeypatch):
+        host_id, event_id, event_row, _locs, repo, svc = self._make_event(started=True)
+
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+
+        body = EventUpdateRequest(segments=[_seg()])
+        with pytest.raises(HTTPException) as exc:
+            svc.update_event(MagicMock(), event_id, host_id, body)
+        assert exc.value.status_code == 400
+        assert "after event has started" in exc.value.detail
+
+    def test_replacing_locations_without_segments_when_segments_exist_rejected(self, monkeypatch):
+        host_id, event_id, event_row, locs, repo, svc = self._make_event(
+            started=False, locations_count=2,
+        )
+
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+        monkeypatch.setattr(repo, "get_event_locations", lambda _db, _eid: locs)
+        monkeypatch.setattr(
+            repo, "get_event_segments",
+            lambda _db, _eid: [{"id": str(uuid4()), "order_index": 0}],
+        )
+
+        new_locs = [
+            LocationRequest(name="L1", latitude=1.0, longitude=2.0, is_primary=True, order_index=0),
+            LocationRequest(name="L2", latitude=3.0, longitude=4.0, is_primary=False, order_index=1),
+        ]
+        body = EventUpdateRequest(locations=new_locs)
+        with pytest.raises(HTTPException) as exc:
+            svc.update_event(MagicMock(), event_id, host_id, body)
+        assert exc.value.status_code == 400
+        assert "clears existing segments" in exc.value.detail
+
+    def test_replacing_locations_without_segments_when_no_segments_allowed(self, monkeypatch):
+        # No existing segments → the silent-clear concern doesn't apply, so
+        # the location update should not be blocked by the segment guard.
+        host_id, event_id, event_row, locs, repo, svc = self._make_event(
+            started=False, locations_count=1,
+        )
+
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+        monkeypatch.setattr(repo, "get_event_locations", lambda _db, _eid: locs)
+        monkeypatch.setattr(repo, "get_event_segments", lambda _db, _eid: [])
+        monkeypatch.setattr(repo, "update_event_atomic", lambda *_a, **_kw: event_row)
+        # Stub get_event_detail to short-circuit the response build (we only
+        # care that the guard didn't raise here).
+        monkeypatch.setattr(svc, "get_event_detail", lambda _db, _eid, _uid: None)
+
+        new_locs = [
+            LocationRequest(name="L1", latitude=1.0, longitude=2.0, is_primary=True, order_index=0),
+        ]
+        body = EventUpdateRequest(locations=new_locs)
+        # Should not raise
+        svc.update_event(MagicMock(), event_id, host_id, body)
+
+    def test_time_change_after_start_rejected(self, monkeypatch):
+        # Sanity-pin the existing FRS-2 guard so it doesn't regress alongside
+        # the new segment guard.
+        host_id, event_id, event_row, _locs, repo, svc = self._make_event(started=True)
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+        body = EventUpdateRequest(start_datetime=datetime.now(UTC) + timedelta(hours=5))
+        with pytest.raises(HTTPException) as exc:
+            svc.update_event(MagicMock(), event_id, host_id, body)
+        assert exc.value.status_code == 400
+        assert "time after event has started" in exc.value.detail
+
+    def test_location_change_after_start_rejected(self, monkeypatch):
+        host_id, event_id, event_row, _locs, repo, svc = self._make_event(started=True)
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+        body = EventUpdateRequest(locations=[
+            LocationRequest(name="L", latitude=0.0, longitude=0.0, is_primary=True, order_index=0),
+        ])
+        with pytest.raises(HTTPException) as exc:
+            svc.update_event(MagicMock(), event_id, host_id, body)
+        assert exc.value.status_code == 400
+        assert "locations after event has started" in exc.value.detail
+
+    def test_segments_validated_against_stored_window_when_body_has_no_dates(self, monkeypatch):
+        # body.segments provided, body.start_datetime / body.end_datetime omitted.
+        # The validator must compare against the stored window (effective fall-back).
+        host_id, event_id, event_row, locs, repo, svc = self._make_event(
+            started=False, locations_count=1,
+        )
+        # Stored window: now+2h to now+6h. We send a segment outside that range.
+        out_of_window_segment = SegmentRequest(
+            location_index=0,
+            order_index=0,
+            start_datetime=datetime.now(UTC) + timedelta(hours=10),
+            end_datetime=datetime.now(UTC) + timedelta(hours=11),
+        )
+
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+        monkeypatch.setattr(repo, "get_event_locations", lambda _db, _eid: locs)
+        monkeypatch.setattr(repo, "get_event_segments", lambda _db, _eid: [])
+
+        body = EventUpdateRequest(segments=[out_of_window_segment])
+        with pytest.raises(HTTPException) as exc:
+            svc.update_event(MagicMock(), event_id, host_id, body)
+        assert exc.value.status_code == 400
+        assert "within event" in exc.value.detail
+
+
+# --- Duplicate-event detection: primary-location scoping --------------------
+
+class TestFindLocationByEventAndNamePrimaryOnly:
+    """find_location_by_event_and_name must filter on is_primary=True so the
+    duplicate-event guard only fires on primary-location collisions
+    (issue #149 FRS-2)."""
+
+    def test_query_includes_is_primary_filter(self):
+        db = MagicMock()
+        # Build a chain that records each .eq() call so we can inspect them.
+        chain = db.table.return_value.select.return_value
+        chain.eq.return_value = chain  # eq returns the same chainable object
+        chain.execute.return_value.data = []
+
+        event_repo.find_location_by_event_and_name(db, "event-id", "Main hall")
+
+        eq_calls = chain.eq.call_args_list
+        kv = {call.args[0]: call.args[1] for call in eq_calls}
+        # Must filter by event_id, name, AND is_primary=True
+        assert kv["event_id"] == "event-id"
+        assert kv["name"] == "Main hall"
+        assert kv["is_primary"] is True
+
+    def test_returns_empty_list_when_data_is_none(self):
+        db = MagicMock()
+        chain = db.table.return_value.select.return_value
+        chain.eq.return_value = chain
+        chain.execute.return_value.data = None
+
+        assert event_repo.find_location_by_event_and_name(db, "e", "n") == []
+
+
+class TestCheckDuplicateEvent:
+    """Service-layer wrapper around find_location_by_event_and_name."""
+
+    def test_no_collision_when_no_matching_event(self, monkeypatch):
+        from app.services import event as svc
+
+        monkeypatch.setattr(event_repo, "find_duplicate_events", lambda *_a, **_k: [])
+        # No HTTPException expected
+        svc.check_duplicate_event(MagicMock(), "host", "Title", "2030-01-01T10:00:00+00:00", "Main hall")
+
+    def test_no_collision_when_primary_name_does_not_match(self, monkeypatch):
+        from app.services import event as svc
+
+        monkeypatch.setattr(
+            event_repo, "find_duplicate_events", lambda *_a, **_k: [{"id": "e1"}],
+        )
+        # Repo is now primary-scoped — when the candidate event has a different
+        # primary, the repo returns []
+        monkeypatch.setattr(
+            event_repo, "find_location_by_event_and_name", lambda *_a, **_k: [],
+        )
+        svc.check_duplicate_event(MagicMock(), "host", "Title", "2030-01-01T10:00:00+00:00", "Main hall")
+
+    def test_collision_when_primary_name_matches(self, monkeypatch):
+        from app.services import event as svc
+
+        monkeypatch.setattr(
+            event_repo, "find_duplicate_events", lambda *_a, **_k: [{"id": "e1"}],
+        )
+        monkeypatch.setattr(
+            event_repo, "find_location_by_event_and_name",
+            lambda *_a, **_k: [{"name": "Main hall"}],
+        )
+        with pytest.raises(HTTPException) as exc:
+            svc.check_duplicate_event(MagicMock(), "host", "Title", "2030-01-01T10:00:00+00:00", "Main hall")
+        assert exc.value.status_code == 409
+        assert "primary location" in exc.value.detail
+
+
+# --- delete_event emits event_deleted before the row is gone ----------------
+
+class TestDeleteEventEmitsBeforeDelete:
+    def _event(self, event_status="cancelled"):
+        host_id = str(uuid4())
+        event_id = str(uuid4())
+        return host_id, event_id, {
+            "id": event_id,
+            "host_id": host_id,
+            "title": "Doomed event",
+            "status": event_status,
+        }
+
+    def test_emits_event_deleted_before_event_repo_delete(self, monkeypatch):
+        from app.repositories import event as repo
+        from app.repositories import image as image_repo_mod
+        from app.services import event as svc
+        from app.services import notification_emitter as ne
+
+        host_id, event_id, event_row = self._event()
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+        monkeypatch.setattr(image_repo_mod, "get_all_event_images", lambda _db, _eid: [])
+
+        call_log: list[str] = []
+
+        def fake_emit(_db, eid, _user, ntype, _msg):
+            call_log.append(f"emit:{ntype}:{eid}")
+            return 0
+
+        def fake_delete(_db, eid):
+            call_log.append(f"delete:{eid}")
+
+        monkeypatch.setattr(ne, "emit_event_notification", fake_emit)
+        monkeypatch.setattr(repo, "delete_event", fake_delete)
+
+        svc.delete_event(MagicMock(), event_id, host_id)
+
+        assert call_log == [f"emit:event_deleted:{event_id}", f"delete:{event_id}"]
+
+    def test_delete_blocked_for_non_terminal_status(self, monkeypatch):
+        from app.repositories import event as repo
+        from app.services import event as svc
+
+        host_id, event_id, event_row = self._event(event_status="published")
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+
+        with pytest.raises(HTTPException) as exc:
+            svc.delete_event(MagicMock(), event_id, host_id)
+        assert exc.value.status_code == 400
+
+    def test_only_host_can_delete(self, monkeypatch):
+        from app.repositories import event as repo
+        from app.services import event as svc
+
+        host_id, event_id, event_row = self._event()
+        monkeypatch.setattr(repo, "get_event_by_id", lambda _db, _eid: event_row)
+
+        someone_else = str(uuid4())
+        with pytest.raises(HTTPException) as exc:
+            svc.delete_event(MagicMock(), event_id, someone_else)
+        assert exc.value.status_code == 403
+
+
+# --- access_rejected emission verification ---------------------------------
+
+class TestAccessRejectedEmission:
+    """Pin the existing rejection flow in services/invite.py so the
+    notification row is always written when a host rejects an access request.
+
+    Mocks every dependency; this is a pure-logic check that the rejected
+    branch of update_access_request inserts a row of type 'access_rejected'.
+    """
+
+    def test_rejection_inserts_access_rejected_notification(self, monkeypatch):
+        from app.models.invite import AccessRequestDecision
+        from app.repositories import event as event_repo_mod
+        from app.repositories import invite as invite_repo_mod
+        from app.repositories import notification as notif_repo_mod
+        from app.repositories import user as user_repo_mod
+        from app.services import invite as invite_svc
+
+        host_id = str(uuid4())
+        event_id = str(uuid4())
+        request_id = str(uuid4())
+        requester_id = str(uuid4())
+
+        event_row = {
+            "id": event_id, "host_id": host_id, "title": "Private gala",
+            "status": "published",
+        }
+        request_row = {
+            "id": request_id, "event_id": event_id, "user_id": requester_id, "status": "pending",
+        }
+        updated_row = {
+            **request_row, "status": "rejected", "resolved_at": "2030-01-01T00:00:00+00:00",
+            "created_at": "2030-01-01T00:00:00+00:00",
+        }
+
+        monkeypatch.setattr(event_repo_mod, "get_event_by_id", lambda _db, _eid: event_row)
+        monkeypatch.setattr(
+            invite_repo_mod, "get_access_request_by_id", lambda _db, _rid: request_row,
+        )
+        monkeypatch.setattr(
+            invite_repo_mod, "update_access_request",
+            lambda _db, _rid, _data: updated_row,
+        )
+        monkeypatch.setattr(
+            user_repo_mod, "get_user_by_id",
+            lambda _db, _uid: {"id": requester_id, "username": "alice"},
+        )
+
+        inserted: list[dict] = []
+        monkeypatch.setattr(
+            notif_repo_mod, "insert_notification",
+            lambda _db, row: inserted.append(row) or row,
+        )
+
+        invite_svc.decide_access_request(
+            MagicMock(),
+            event_id=event_id,
+            request_id=request_id,
+            user_id=host_id,
+            body=AccessRequestDecision(status="rejected"),
+        )
+
+        rejected_rows = [r for r in inserted if r.get("type") == "access_rejected"]
+        assert len(rejected_rows) == 1
+        row = rejected_rows[0]
+        assert row["user_id"] == requester_id
+        assert row["event_id"] == event_id
+        assert row["is_read"] is False
+
+    def test_approval_does_not_emit_access_rejected(self, monkeypatch):
+        # Make sure the rejection branch is exclusive — approving must not
+        # write an 'access_rejected' row.
+        from app.models.invite import AccessRequestDecision
+        from app.repositories import event as event_repo_mod
+        from app.repositories import invite as invite_repo_mod
+        from app.repositories import notification as notif_repo_mod
+        from app.repositories import user as user_repo_mod
+        from app.services import invite as invite_svc
+
+        host_id = str(uuid4())
+        event_id = str(uuid4())
+        request_id = str(uuid4())
+        requester_id = str(uuid4())
+
+        event_row = {"id": event_id, "host_id": host_id, "title": "T", "status": "published"}
+        request_row = {
+            "id": request_id, "event_id": event_id, "user_id": requester_id, "status": "pending",
+        }
+        updated_row = {**request_row, "status": "approved", "created_at": "2030-01-01T00:00:00+00:00"}
+
+        monkeypatch.setattr(event_repo_mod, "get_event_by_id", lambda *_a, **_k: event_row)
+        monkeypatch.setattr(invite_repo_mod, "get_access_request_by_id", lambda *_a, **_k: request_row)
+        monkeypatch.setattr(invite_repo_mod, "update_access_request", lambda *_a, **_k: updated_row)
+        monkeypatch.setattr(invite_repo_mod, "insert_access_grant", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            user_repo_mod, "get_user_by_id",
+            lambda *_a, **_k: {"id": requester_id, "username": "alice"},
+        )
+
+        inserted: list[dict] = []
+        monkeypatch.setattr(
+            notif_repo_mod, "insert_notification",
+            lambda _db, row: inserted.append(row) or row,
+        )
+
+        invite_svc.decide_access_request(
+            MagicMock(),
+            event_id=event_id,
+            request_id=request_id,
+            user_id=host_id,
+            body=AccessRequestDecision(status="approved"),
+        )
+
+        assert all(r.get("type") != "access_rejected" for r in inserted)


### PR DESCRIPTION
## Summary

Closes #149 backend scope. Adds itinerary segments on top of the existing multi-location model, tightens duplicate detection, and closes the `event_deleted` / `access_rejected` notification gaps.

- New optional `segments[]` on `POST /events` and `PUT /events/{id}`, surfaced ordered on `GET /events/{id}`. Each segment ties one location (referenced by **request-array position**) to a time window with an optional description.
- Validation: `location_index` in range, timezone-aware `end > start`, segment within event window, contiguous `order_index` from 0, non-overlapping when sorted by order (location-independent).
- Lifecycle: time / location / **segment** updates rejected after `start_datetime` is in the past (FRS-2). Replacing `locations` without `segments` rejects rather than silently CASCADE-wiping (caller must pass `segments: []` to opt into clearing).
- Duplicate detection scoped to **primary** location (FRS-2) — `find_location_by_event_and_name` now filters `is_primary=True`.
- `delete_event` emits `event_deleted` to going attendees + bookmarkers **before** the row is removed; `notifications.event_id` is `ON DELETE SET NULL` so rows survive with `event_id` cleared.
- `access_rejected` is verified + tested (already implemented in `services/invite.py`).

## Schema migrations (must run before this code is deployed)

Apply in Supabase SQL Editor:

1. [`backend/sql/012_create_event_segments.sql`](backend/sql/012_create_event_segments.sql) — new `event_segments` table.
2. [`backend/sql/013_atomic_event_rpc_segments.sql`](backend/sql/013_atomic_event_rpc_segments.sql) — replaces `009`/`010`. Adds `p_segments` to both atomic event RPCs.

The new RPCs use an explicit PL/pgSQL `FOR` loop to accumulate location UUIDs in request-array order so `v_location_ids[i+1] == id of p_locations[i]` is rock solid (the previous draft relied on `RETURNING` order from `INSERT ... SELECT`, which is not spec-guaranteed). `get_event_locations` is now deterministically ordered `(created_at, order_index, id)` to match the RPC's fallback when a PATCH sends only `segments`.

## Test plan

- [ ] CI lint (ruff): `pyproject.toml` config; verified locally with `python3 -m ruff check .` → all checks passed.
- [ ] CI `unit-fast` shard runs `tests/test_*_unit.py` including the new [`test_segments_unit.py`](backend/tests/test_segments_unit.py): Pydantic schema, repo RPC wrappers, `validate_segments` matrix (overlap / inverted / window / contiguous order / location_index range / overlap-when-unsorted / location-independent overlap), `_build_segment_rows`, `update_event` guards (after-start, locations-replace-without-segments, validates against stored window when body has no dates), primary-only duplicate detection (repo + service), `delete_event` emit-before-delete ordering, `access_rejected` exclusivity.
- [ ] CI `events` shard exercises the `TestEventSegments` class in [`tests/test_events.py`](backend/tests/test_events.py) including the **regression test** `test_segment_location_index_matches_request_position_when_order_index_is_reversed` that pins the contract when `order_index` is non-monotonic.
- [ ] CI `media-notifications` shard exercises `TestDeleteNotification` in [`tests/test_notification_emitter.py`](backend/tests/test_notification_emitter.py): notifies going attendees + bookmarkers with `event_id` `NULL` after delete, excludes host, excludes interested-only.
- [ ] CI `comments-invites` shard exercises `TestAccessDecisionNotifications` in [`tests/test_invites.py`](backend/tests/test_invites.py): rejection persists `access_rejected`; approval path doesn't.
- [ ] Manual smoke (post-deploy): create event with non-monotonic `order_index` locations and verify segments resolve correctly via `GET /events/{id}`.

## Notes for the reviewer (@canemirbora4)

- The order-vs-time interpretation chosen is the strict one: `order_index` is the canonical order *and* segments must be non-overlapping in time. Issue spec said "ordered segments, no time overlaps"; this picks the unambiguous reading. Open to changing if you want it looser.
- README has a new "Itinerary segments" section with a JSON example and the `location_index` semantics for partial PATCH ([backend/README.md](backend/README.md)).
