### PR TITLE
feat(backend): free-text reviews on host ratings (issue #235)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 # Local notes (not for repo)
 IMPROVEMENTS.md
 ISSUE_154_ROADMAP.md
+ISSUE_235_ROADMAP.md

--- a/backend/README.md
+++ b/backend/README.md
@@ -279,8 +279,50 @@ Notes:
 |--------|----------|------|-------------|
 | GET | /users/me/bookmarks | Bearer | List current user's bookmarks |
 | PUT | /users/me | Bearer | Update current user's profile |
-| GET | /users/{id}/profile | Optional | Get host profile details |
-| POST | /users/{id}/ratings | Bearer | Rate a host |
+| GET | /users/{id}/profile | Optional | Get host profile details (avg rating + count summary) |
+| POST | /users/{id}/ratings | Bearer | Rate a host (1–5 stars + optional text review) — returns 201 |
+| GET | /users/{id}/reviews | - | Paginated reviews for a host, newest-first |
+
+**Rating eligibility:** the rater must have attended at least one *ended* event hosted by the target user. Self-rating is rejected with 400. Repeated POSTs from the same rater overwrite the previous score and review text (upsert).
+
+**Optional review text:** `POST /users/{id}/ratings` accepts an optional `review_text` field (max 1000 characters). Whitespace-only values are normalised to `null` server-side. The same payload shape is used for new ratings and for editing an existing one.
+
+```jsonc
+// POST /users/{host_id}/ratings — minimal (back-compat with star-only clients)
+{ "score": 4.5 }
+
+// POST /users/{host_id}/ratings — with review text
+{ "score": 4.5, "review_text": "Walk was excellent — leader was clear and friendly." }
+```
+
+**Reviews list:** `GET /users/{id}/reviews?page=1&page_size=20` returns reviews ordered by `created_at DESC, id DESC`. Star-only ratings are included with `review_text: null` so the list mirrors the aggregate rating count on the profile. Unknown host → 404 (mirrors `GET /users/{id}/profile`); existing host with no ratings → 200 with empty `items`.
+
+```json
+{
+  "items": [
+    {
+      "id": "…",
+      "rater_id": "…",
+      "rater_username": "alice",
+      "score": 5.0,
+      "review_text": "Walk was excellent",
+      "created_at": "2030-06-01T13:30:00+00:00"
+    },
+    {
+      "id": "…",
+      "rater_id": "…",
+      "rater_username": "bob",
+      "score": 4.0,
+      "review_text": null,
+      "created_at": "2030-06-01T12:00:00+00:00"
+    }
+  ],
+  "total": 2,
+  "page": 1,
+  "page_size": 20,
+  "total_pages": 1
+}
+```
 
 ## Project Structure
 
@@ -337,13 +379,16 @@ backend/
 │   ├── test_invites.py       # Invite/Access request tests (28)
 │   ├── test_notifications.py # Notification tests (12)
 │   ├── test_notification_emitter.py  # Notification emission tests (11)
+│   ├── test_reviews_unit.py  # Review/rating-text unit tests (issue #235)
+│   ├── test_users.py         # User/profile/rating integration tests
 │   └── test_health.py        # Health check test (1)
-├── sql/
-│   ├── 001_create_tables.sql         # Auth tables
-│   ├── 002_create_core_tables.sql    # Core data model tables
-│   ├── 003_pg_cron_auto_end.sql      # Auto-end expired events
-│   ├── 005_create_invite_tables.sql  # Invite/Access tables
-│   └── 006_reconcile_invite_schema.sql  # Manual Supabase reconcile script
+├── sql/                                  # Apply manually in Supabase SQL Editor (no runner)
+│   ├── 001_create_tables.sql             # Auth tables
+│   ├── 002_create_core_tables.sql        # Core data model tables
+│   ├── 003_pg_cron_auto_end.sql          # Auto-end expired events
+│   ├── 005_create_invite_tables.sql      # Invite/Access tables
+│   ├── 006_reconcile_invite_schema.sql   # Manual Supabase reconcile script
+│   └── 014_add_rating_review_text.sql    # Optional free-text review on ratings (issue #235)
 ├── requirements.txt
 ├── pyproject.toml            # Ruff + pytest config
 ├── Dockerfile

--- a/backend/app/models/rating.py
+++ b/backend/app/models/rating.py
@@ -9,10 +9,14 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class RatingRequest(BaseModel):
     score: Decimal = Field(ge=1.00, le=5.00, max_digits=3, decimal_places=2)
+    review_text: str | None = Field(default=None, max_length=1000)
 
     model_config = ConfigDict(
         json_schema_extra={
-            "example": {"score": 4.5}
+            "example": {
+                "score": 4.5,
+                "review_text": "Walk was excellent — leader was clear and friendly.",
+            }
         }
     )
 
@@ -22,4 +26,29 @@ class RatingResponse(BaseModel):
     rater_id: UUID
     host_id: UUID
     score: Decimal
+    review_text: str | None = None
     created_at: datetime
+
+
+class ReviewListItemResponse(BaseModel):
+    """Single review row for the host's reviews-list endpoint.
+
+    `review_text` is None for star-only ratings; the frontend renders a
+    "No written review" placeholder for those rows. `rater_username` lets
+    the UI show the rater's name without a separate user lookup.
+    """
+    id: UUID
+    rater_id: UUID
+    rater_username: str
+    score: Decimal
+    review_text: str | None = None
+    created_at: datetime
+
+
+class ReviewListResponse(BaseModel):
+    """Paginated reviews-by-host result, ordered newest-first."""
+    items: list[ReviewListItemResponse]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int

--- a/backend/app/repositories/rating.py
+++ b/backend/app/repositories/rating.py
@@ -2,11 +2,13 @@
 
 from supabase import Client
 
+_RATING_COLS = "id,rater_id,host_id,score,review_text,created_at"
+
 
 def get_rating(db: Client, rater_id: str, host_id: str) -> dict | None:
     result = (
         db.table("ratings")
-        .select("id,rater_id,host_id,score,created_at")
+        .select(_RATING_COLS)
         .eq("rater_id", rater_id)
         .eq("host_id", host_id)
         .execute()
@@ -34,3 +36,41 @@ def get_host_rating_stats(db: Client, host_id: str) -> dict:
     total_score = sum(float(row["score"]) for row in result.data)
     count = len(result.data)
     return {"average": total_score / count, "count": count}
+
+
+def list_reviews_for_host(
+    db: Client, host_id: str, *, page: int = 1, page_size: int = 20,
+) -> tuple[list[dict], int]:
+    """Return (rows, total_count) of ratings for a host, newest-first.
+
+    Uses a two-query pattern (count + page) to avoid PostgREST's
+    embedded-relationship name coupling (`users!ratings_rater_id_fkey(...)`)
+    — the FK name is environment-specific and silently fails if it differs
+    in Supabase. The service layer joins `rater_username` separately via
+    `user_repo.get_users_by_ids`.
+    """
+    count_result = (
+        db.table("ratings")
+        .select("id", count="exact")
+        .eq("host_id", host_id)
+        .execute()
+    )
+    total = count_result.count or 0
+
+    if total == 0:
+        return [], 0
+
+    offset = (page - 1) * page_size
+    if offset >= total:
+        return [], total
+
+    result = (
+        db.table("ratings")
+        .select(_RATING_COLS)
+        .eq("host_id", host_id)
+        .order("created_at", desc=True)
+        .order("id", desc=True)
+        .range(offset, offset + page_size - 1)
+        .execute()
+    )
+    return result.data or [], total

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -9,11 +9,11 @@ from app.database import get_supabase
 from app.middleware.auth import get_current_user_id, get_optional_user_id
 from app.models.bookmark import BookmarkListResponse
 from app.models.profile import HostProfileResponse, ProfileUpdateRequest
-from app.models.rating import RatingRequest, RatingResponse
+from app.models.rating import RatingRequest, RatingResponse, ReviewListResponse
 from app.models.user import UserResponse
 from app.services.bookmark import list_user_bookmarks
 from app.services.profile import get_host_profile, update_profile
-from app.services.rating import rate_host
+from app.services.rating import list_reviews, rate_host
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -46,11 +46,23 @@ def get_user_profile(
     return get_host_profile(db, str(target_user_id), current_user_id)
 
 
-@router.post("/{host_id}/ratings", response_model=RatingResponse)
+@router.post("/{host_id}/ratings", response_model=RatingResponse, status_code=201)
 def rate_host_endpoint(
     host_id: UUID,
     body: RatingRequest,
     rater_id: str = Depends(get_current_user_id),
 ):
     db = get_supabase()
-    return rate_host(db, rater_id, str(host_id), Decimal(str(body.score)))
+    return rate_host(
+        db, rater_id, str(host_id), Decimal(str(body.score)), body.review_text,
+    )
+
+
+@router.get("/{host_id}/reviews", response_model=ReviewListResponse)
+def list_host_reviews(
+    host_id: UUID,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+):
+    db = get_supabase()
+    return list_reviews(db, str(host_id), page=page, page_size=page_size)

--- a/backend/app/services/rating.py
+++ b/backend/app/services/rating.py
@@ -1,18 +1,40 @@
-"""Rating service — business logic for host ratings."""
+"""Rating service — business logic for host ratings and review listing."""
 
 from decimal import Decimal
 
 from fastapi import HTTPException, status
 from supabase import Client
 
-from app.models.rating import RatingResponse
+from app.models.rating import (
+    RatingResponse,
+    ReviewListItemResponse,
+    ReviewListResponse,
+)
 from app.repositories import attendance as attendance_repo
 from app.repositories import profile as profile_repo
 from app.repositories import rating as rating_repo
 from app.repositories import user as user_repo
 
 
-def rate_host(db: Client, rater_id: str, host_id: str, score: Decimal) -> RatingResponse:
+def _normalise_review_text(text: str | None) -> str | None:
+    """Trim surrounding whitespace; whitespace-only → None.
+
+    Decided in the issue planning: locked decision #4 — keep DB free of
+    sham reviews; placeholder rendering on frontend works correctly.
+    """
+    if text is None:
+        return None
+    cleaned = text.strip()
+    return cleaned if cleaned else None
+
+
+def rate_host(
+    db: Client,
+    rater_id: str,
+    host_id: str,
+    score: Decimal,
+    review_text: str | None = None,
+) -> RatingResponse:
     if rater_id == host_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -38,11 +60,12 @@ def rate_host(db: Client, rater_id: str, host_id: str, score: Decimal) -> Rating
             detail="You can only rate a host after attending one of their ended events"
         )
 
-    # Upsert the rating
+    # Upsert the rating (review_text overwrites previous value — locked decision #5)
     rating = rating_repo.upsert_rating(db, {
         "rater_id": rater_id,
         "host_id": host_id,
-        "score": float(score)
+        "score": float(score),
+        "review_text": _normalise_review_text(review_text),
     })
 
     return RatingResponse(
@@ -50,5 +73,49 @@ def rate_host(db: Client, rater_id: str, host_id: str, score: Decimal) -> Rating
         rater_id=rating["rater_id"],
         host_id=rating["host_id"],
         score=Decimal(str(rating["score"])),
+        review_text=rating.get("review_text"),
         created_at=rating["created_at"],
+    )
+
+
+def list_reviews(
+    db: Client, host_id: str, *, page: int = 1, page_size: int = 20,
+) -> ReviewListResponse:
+    """Return paginated reviews for a host, newest-first.
+
+    Mirrors `GET /users/{id}/profile`: 404 if the host does not exist,
+    200 with empty `items` if the host exists but has no ratings yet.
+    """
+    host = user_repo.get_user_by_id(db, host_id)
+    if not host:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    rows, total = rating_repo.list_reviews_for_host(
+        db, host_id, page=page, page_size=page_size,
+    )
+    total_pages = (total + page_size - 1) // page_size if total > 0 else 0
+
+    if not rows:
+        return ReviewListResponse(
+            items=[], total=total, page=page, page_size=page_size, total_pages=total_pages,
+        )
+
+    rater_ids = list({row["rater_id"] for row in rows})
+    rater_users = user_repo.get_users_by_ids(db, rater_ids)
+    username_by_id = {u["id"]: u.get("username", "unknown") for u in rater_users}
+
+    items = [
+        ReviewListItemResponse(
+            id=row["id"],
+            rater_id=row["rater_id"],
+            rater_username=username_by_id.get(row["rater_id"], "unknown"),
+            score=Decimal(str(row["score"])),
+            review_text=row.get("review_text"),
+            created_at=row["created_at"],
+        )
+        for row in rows
+    ]
+
+    return ReviewListResponse(
+        items=items, total=total, page=page, page_size=page_size, total_pages=total_pages,
     )

--- a/backend/sql/014_add_rating_review_text.sql
+++ b/backend/sql/014_add_rating_review_text.sql
@@ -1,0 +1,26 @@
+-- 014: Free-text review alongside star score (issue #230 / #235)
+-- Adds an optional `review_text` column to the ratings table so attendees can
+-- leave a written review next to their star score. Existing rows are
+-- unaffected (review_text NULL).
+--
+-- Whitespace-only text is normalised to NULL in the service layer, so the DB
+-- only sees actual text or NULL. Length is enforced by a CHECK constraint
+-- (≤ 1000 chars) — Pydantic also enforces this at the request boundary,
+-- but the DB constraint is the last line of defence.
+--
+-- Run this in the Supabase SQL Editor BEFORE deploying the matching backend
+-- code, or every rating insert will fail (the request schema accepts
+-- `review_text` but the column does not exist yet).
+
+ALTER TABLE public.ratings
+    ADD COLUMN IF NOT EXISTS review_text TEXT;
+
+ALTER TABLE public.ratings
+    DROP CONSTRAINT IF EXISTS ratings_review_text_length;
+ALTER TABLE public.ratings
+    ADD CONSTRAINT ratings_review_text_length
+    CHECK (review_text IS NULL OR char_length(review_text) <= 1000);
+
+-- Supports newest-first reviews-by-host pagination.
+CREATE INDEX IF NOT EXISTS idx_ratings_host_created
+    ON public.ratings (host_id, created_at DESC);

--- a/backend/tests/test_reviews_unit.py
+++ b/backend/tests/test_reviews_unit.py
@@ -1,0 +1,455 @@
+"""Phase 1 unit tests for issue #235 (free-text reviews on ratings).
+
+Covers Pydantic validation, repository read/write contracts, and the
+whitespace-normalisation logic in the service layer. All DB calls are
+mocked — these run in the `unit-fast` CI shard via `tests/test_*_unit.py`.
+
+Integration tests (real Supabase, eligibility, end-to-end POST/GET) are
+covered separately in tests/test_users.py.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.rating import (
+    RatingRequest,
+    RatingResponse,
+    ReviewListItemResponse,
+    ReviewListResponse,
+)
+from app.repositories import rating as rating_repo
+from app.services.rating import _normalise_review_text
+
+
+# Override the autouse cleanup_test_users fixture from conftest.py: these
+# tests never touch real Supabase (db is mocked everywhere), so the
+# session-scoped `db` dependency would otherwise force a connection on
+# every teardown — fragile when run locally without DB env, and pointless
+# even in CI. Replace with a no-op so the unit shard is truly DB-free.
+@pytest.fixture(autouse=True)
+def cleanup_test_users():
+    yield
+
+
+# --- RatingRequest schema --------------------------------------------------
+
+class TestRatingRequestSchema:
+    def test_score_only_payload_back_compat(self):
+        # Existing clients that don't know about review_text must keep working.
+        body = RatingRequest(score=Decimal("4.5"))
+        assert body.review_text is None
+
+    def test_score_with_text(self):
+        body = RatingRequest(score=Decimal("5.0"), review_text="Great host!")
+        assert body.review_text == "Great host!"
+
+    def test_text_at_max_length_accepted(self):
+        body = RatingRequest(score=Decimal("4.0"), review_text="x" * 1000)
+        assert len(body.review_text) == 1000
+
+    def test_text_over_max_length_rejected(self):
+        with pytest.raises(ValidationError):
+            RatingRequest(score=Decimal("4.0"), review_text="x" * 1001)
+
+    def test_review_text_can_be_explicit_null(self):
+        body = RatingRequest(score=Decimal("4.0"), review_text=None)
+        assert body.review_text is None
+
+    def test_score_below_floor_rejected(self):
+        with pytest.raises(ValidationError):
+            RatingRequest(score=Decimal("0.5"))
+
+    def test_score_above_ceiling_rejected(self):
+        with pytest.raises(ValidationError):
+            RatingRequest(score=Decimal("5.5"))
+
+
+# --- Response shapes -------------------------------------------------------
+
+class TestRatingResponseShape:
+    def test_round_trips_with_text(self):
+        rid = uuid4()
+        rater = uuid4()
+        host = uuid4()
+        now = datetime.now(UTC)
+        resp = RatingResponse(
+            id=rid, rater_id=rater, host_id=host,
+            score=Decimal("4.5"), review_text="Walk was excellent",
+            created_at=now,
+        )
+        assert resp.review_text == "Walk was excellent"
+
+    def test_review_text_optional(self):
+        resp = RatingResponse(
+            id=uuid4(), rater_id=uuid4(), host_id=uuid4(),
+            score=Decimal("3.5"), created_at=datetime.now(UTC),
+        )
+        assert resp.review_text is None
+
+
+class TestReviewListResponseShape:
+    def test_empty_list(self):
+        resp = ReviewListResponse(items=[], total=0, page=1, page_size=20, total_pages=0)
+        assert resp.items == []
+
+    def test_item_with_username_and_null_text(self):
+        item = ReviewListItemResponse(
+            id=uuid4(),
+            rater_id=uuid4(),
+            rater_username="alice",
+            score=Decimal("4.0"),
+            review_text=None,
+            created_at=datetime.now(UTC),
+        )
+        # Star-only reviews surface in the list with review_text=None
+        # (locked decision #1).
+        assert item.review_text is None
+        assert item.rater_username == "alice"
+
+
+# --- Whitespace normalisation (locked decision #4) -------------------------
+
+class TestNormaliseReviewText:
+    def test_none_passthrough(self):
+        assert _normalise_review_text(None) is None
+
+    def test_empty_string_becomes_none(self):
+        assert _normalise_review_text("") is None
+
+    def test_whitespace_only_becomes_none(self):
+        assert _normalise_review_text("   \t\n  ") is None
+
+    def test_strips_surrounding_whitespace(self):
+        assert _normalise_review_text("  good walk  ") == "good walk"
+
+    def test_preserves_inner_whitespace(self):
+        assert _normalise_review_text("very  helpful   leader") == "very  helpful   leader"
+
+    def test_unicode_text_preserved(self):
+        assert _normalise_review_text("çok iyi 👍") == "çok iyi 👍"
+
+
+# --- Repository: list_reviews_for_host -------------------------------------
+
+class TestListReviewsForHost:
+    def _db_with_count_and_rows(self, count, rows):
+        db = MagicMock()
+
+        # Two distinct chains: one for count, one for paged data. We tell
+        # them apart by checking which `select` overload fires.
+        def select_side_effect(*args, **kwargs):
+            chain = MagicMock()
+            if "count" in kwargs:
+                # count path: db.table(..).select("id", count="exact").eq(..).execute()
+                chain.eq.return_value.execute.return_value = MagicMock(
+                    count=count, data=[{"id": "x"}] * count,
+                )
+            else:
+                # data path: select(_RATING_COLS).eq.order.order.range.execute
+                page = chain.eq.return_value.order.return_value.order.return_value.range.return_value
+                page.execute.return_value.data = rows
+            return chain
+
+        db.table.return_value.select.side_effect = select_side_effect
+        return db
+
+    def test_zero_total_returns_empty(self):
+        db = self._db_with_count_and_rows(0, [])
+        rows, total = rating_repo.list_reviews_for_host(db, "host-id", page=1, page_size=20)
+        assert rows == []
+        assert total == 0
+
+    def test_offset_past_end_returns_empty_list_but_keeps_total(self):
+        db = self._db_with_count_and_rows(2, [])
+        rows, total = rating_repo.list_reviews_for_host(db, "host-id", page=99, page_size=20)
+        assert rows == []
+        assert total == 2
+
+    def test_returns_rows_and_total(self):
+        sample = [
+            {"id": str(uuid4()), "rater_id": str(uuid4()), "host_id": "h",
+             "score": 5.0, "review_text": "a", "created_at": "2030-01-02T00:00:00+00:00"},
+            {"id": str(uuid4()), "rater_id": str(uuid4()), "host_id": "h",
+             "score": 4.0, "review_text": None, "created_at": "2030-01-01T00:00:00+00:00"},
+        ]
+        db = self._db_with_count_and_rows(2, sample)
+        rows, total = rating_repo.list_reviews_for_host(db, "h", page=1, page_size=20)
+        assert total == 2
+        assert rows == sample
+
+    def test_query_parameters_are_passed_in_order(self):
+        # Pin: filter first by host_id, order by created_at desc then id desc.
+        db = MagicMock()
+        sel = db.table.return_value.select
+        # Make both invocations return the same chain so we can observe calls.
+        chain = sel.return_value
+        chain.eq.return_value = chain
+        chain.execute.return_value = MagicMock(count=1, data=[{"id": "x"}])
+        chain.order.return_value = chain
+        chain.range.return_value = chain
+
+        rating_repo.list_reviews_for_host(db, "host-id", page=1, page_size=10)
+
+        # Check eq("host_id", ...) was called on both queries.
+        eq_calls = [c.args for c in chain.eq.call_args_list]
+        assert ("host_id", "host-id") in eq_calls
+        # Check the ordering on the data query: created_at desc, id desc.
+        order_calls = [(c.args, c.kwargs) for c in chain.order.call_args_list]
+        assert (("created_at",), {"desc": True}) in order_calls
+        assert (("id",), {"desc": True}) in order_calls
+
+
+# --- Repository: upsert_rating now carries review_text ---------------------
+
+class TestUpsertRatingCarriesReviewText:
+    def test_review_text_in_payload(self):
+        db = MagicMock()
+        db.table.return_value.upsert.return_value.execute.return_value.data = [
+            {"id": str(uuid4()), "rater_id": "r", "host_id": "h",
+             "score": 4.0, "review_text": "Nice!", "created_at": "2030-01-01T00:00:00+00:00"},
+        ]
+        rating_repo.upsert_rating(db, {
+            "rater_id": "r", "host_id": "h", "score": 4.0, "review_text": "Nice!",
+        })
+        upsert_args, upsert_kwargs = db.table.return_value.upsert.call_args
+        assert upsert_args[0] == {
+            "rater_id": "r", "host_id": "h", "score": 4.0, "review_text": "Nice!",
+        }
+        # on_conflict must remain the composite unique key
+        assert upsert_kwargs["on_conflict"] == "rater_id,host_id"
+
+    def test_review_text_null_in_payload(self):
+        db = MagicMock()
+        db.table.return_value.upsert.return_value.execute.return_value.data = [
+            {"id": str(uuid4()), "rater_id": "r", "host_id": "h",
+             "score": 5.0, "review_text": None, "created_at": "2030-01-01T00:00:00+00:00"},
+        ]
+        rating_repo.upsert_rating(db, {
+            "rater_id": "r", "host_id": "h", "score": 5.0, "review_text": None,
+        })
+        upsert_args, _ = db.table.return_value.upsert.call_args
+        assert upsert_args[0]["review_text"] is None
+
+
+# --- Service: rate_host trims and forwards review_text correctly -----------
+
+class TestRateHostService:
+    """Pin rate_host's interaction with the repo layer.
+
+    All eligibility-chain dependencies are mocked so we focus on the new
+    review_text wiring: the upsert payload must contain trimmed text (or
+    None), and the response must surface the same text.
+    """
+
+    def _setup(self, monkeypatch, *, captured_payload):
+        from app.repositories import attendance as attendance_repo
+        from app.repositories import profile as profile_repo
+        from app.repositories import user as user_repo
+        from app.services import rating as rating_svc
+
+        monkeypatch.setattr(
+            user_repo, "get_user_by_id",
+            lambda _db, _uid: {"id": _uid, "username": "host"},
+        )
+        monkeypatch.setattr(
+            profile_repo, "get_hosted_events", lambda _db, _hid: [{"id": "e1"}],
+        )
+        monkeypatch.setattr(
+            attendance_repo, "has_attended_ended_event_by_host",
+            lambda _db, _rid, _hid: True,
+        )
+
+        def fake_upsert(_db, payload):
+            captured_payload.append(payload)
+            return {
+                "id": str(uuid4()),
+                "rater_id": payload["rater_id"],
+                "host_id": payload["host_id"],
+                "score": payload["score"],
+                "review_text": payload["review_text"],
+                "created_at": "2030-01-01T00:00:00+00:00",
+            }
+
+        monkeypatch.setattr(rating_repo, "upsert_rating", fake_upsert)
+        return rating_svc
+
+    def test_trims_surrounding_whitespace_and_forwards_text(self, monkeypatch):
+        captured: list[dict] = []
+        svc = self._setup(monkeypatch, captured_payload=captured)
+
+        # RatingResponse validates rater_id/host_id as UUIDs, so the test
+        # must pass real UUID strings end-to-end.
+        rater_id = str(uuid4())
+        host_id = str(uuid4())
+        resp = svc.rate_host(
+            MagicMock(), rater_id=rater_id, host_id=host_id,
+            score=Decimal("4.5"), review_text="  Walk was excellent  ",
+        )
+
+        assert captured[0]["review_text"] == "Walk was excellent"
+        assert resp.review_text == "Walk was excellent"
+        assert resp.score == Decimal("4.5")
+
+    def test_whitespace_only_text_normalised_to_null_in_repo_call(self, monkeypatch):
+        captured: list[dict] = []
+        svc = self._setup(monkeypatch, captured_payload=captured)
+
+        rater_id = str(uuid4())
+        host_id = str(uuid4())
+        resp = svc.rate_host(
+            MagicMock(), rater_id=rater_id, host_id=host_id,
+            score=Decimal("3.0"), review_text="   \n\t  ",
+        )
+
+        assert captured[0]["review_text"] is None
+        assert resp.review_text is None
+
+    def test_missing_review_text_defaults_to_null(self, monkeypatch):
+        captured: list[dict] = []
+        svc = self._setup(monkeypatch, captured_payload=captured)
+
+        rater_id = str(uuid4())
+        host_id = str(uuid4())
+        resp = svc.rate_host(
+            MagicMock(), rater_id=rater_id, host_id=host_id, score=Decimal("5.0"),
+        )
+
+        assert captured[0]["review_text"] is None
+        assert resp.review_text is None
+
+    def test_self_rating_blocked_before_repo_call(self, monkeypatch):
+        from fastapi import HTTPException
+
+        from app.services import rating as rating_svc
+        captured: list[dict] = []
+        # Even with eligibility chain mocked, rater_id == host_id must short-circuit
+        # (raises before the RatingResponse build, so any string id is fine here).
+        monkeypatch.setattr(rating_repo, "upsert_rating",
+                            lambda _db, p: captured.append(p) or {"id": "x"})
+
+        same_id = str(uuid4())
+        with pytest.raises(HTTPException) as exc:
+            rating_svc.rate_host(
+                MagicMock(), rater_id=same_id, host_id=same_id,
+                score=Decimal("4.0"), review_text="hi",
+            )
+        assert exc.value.status_code == 400
+        assert captured == []  # never reached the repo
+
+
+# --- Service: list_reviews paginates + maps usernames ----------------------
+
+class TestListReviewsService:
+    def _patch_chain(self, monkeypatch, *, host_exists=True, rows=None, total=0):
+        from app.repositories import user as user_repo
+        from app.services import rating as rating_svc
+
+        if host_exists:
+            monkeypatch.setattr(
+                user_repo, "get_user_by_id",
+                lambda _db, _uid: {"id": _uid, "username": "host"},
+            )
+        else:
+            monkeypatch.setattr(user_repo, "get_user_by_id", lambda _db, _uid: None)
+
+        monkeypatch.setattr(
+            rating_repo, "list_reviews_for_host",
+            lambda _db, _hid, *, page, page_size: (rows or [], total),
+        )
+
+        # Maps each rater_id to "user-<short>" for stable assertions
+        def fake_users_by_ids(_db, ids):
+            return [{"id": uid, "username": f"user-{uid[:4]}"} for uid in ids]
+
+        monkeypatch.setattr(user_repo, "get_users_by_ids", fake_users_by_ids)
+        return rating_svc
+
+    def test_unknown_host_returns_404(self, monkeypatch):
+        from fastapi import HTTPException
+        svc = self._patch_chain(monkeypatch, host_exists=False)
+        with pytest.raises(HTTPException) as exc:
+            svc.list_reviews(MagicMock(), "missing-id")
+        assert exc.value.status_code == 404
+
+    def test_known_host_no_ratings_returns_200_empty(self, monkeypatch):
+        # Locked decision #3: existing host with no ratings → 200 + empty items
+        svc = self._patch_chain(monkeypatch, host_exists=True, rows=[], total=0)
+        resp = svc.list_reviews(MagicMock(), "host-id", page=1, page_size=20)
+        assert resp.total == 0
+        assert resp.items == []
+        assert resp.total_pages == 0
+
+    def test_pagination_math(self, monkeypatch):
+        # 3 reviews, page_size=2 → total_pages=2
+        rid_a, rid_b = str(uuid4()), str(uuid4())
+        rows = [
+            {"id": str(uuid4()), "rater_id": rid_a, "host_id": "h", "score": 5.0,
+             "review_text": "a", "created_at": "2030-01-02T00:00:00+00:00"},
+            {"id": str(uuid4()), "rater_id": rid_b, "host_id": "h", "score": 4.0,
+             "review_text": None, "created_at": "2030-01-01T00:00:00+00:00"},
+        ]
+        svc = self._patch_chain(monkeypatch, host_exists=True, rows=rows, total=3)
+        resp = svc.list_reviews(MagicMock(), "h", page=1, page_size=2)
+        assert resp.total == 3
+        assert resp.page == 1
+        assert resp.page_size == 2
+        assert resp.total_pages == 2
+        assert len(resp.items) == 2
+
+    def test_username_mapping_is_correct(self, monkeypatch):
+        rid_a = str(uuid4())
+        rid_b = str(uuid4())
+        rows = [
+            {"id": str(uuid4()), "rater_id": rid_a, "host_id": "h", "score": 5.0,
+             "review_text": "great", "created_at": "2030-01-02T00:00:00+00:00"},
+            {"id": str(uuid4()), "rater_id": rid_b, "host_id": "h", "score": 4.0,
+             "review_text": None, "created_at": "2030-01-01T00:00:00+00:00"},
+        ]
+        svc = self._patch_chain(monkeypatch, host_exists=True, rows=rows, total=2)
+        resp = svc.list_reviews(MagicMock(), "h")
+
+        by_rater = {item.rater_id: item for item in resp.items}
+        # Locked decision #1: star-only ratings show up with review_text=None
+        assert by_rater[uuid4_to_uuid(rid_b)].review_text is None
+        assert by_rater[uuid4_to_uuid(rid_a)].review_text == "great"
+        # Username mapped from get_users_by_ids stub
+        assert resp.items[0].rater_username == f"user-{rows[0]['rater_id'][:4]}"
+        assert resp.items[1].rater_username == f"user-{rows[1]['rater_id'][:4]}"
+
+    def test_unknown_rater_falls_back_to_unknown_username(self, monkeypatch):
+        # If user lookup returns no row for a rater_id, surface "unknown"
+        # rather than crashing. Defensive — a CASCADE-deleted user could
+        # leave an orphan rating in flight.
+        from app.repositories import user as user_repo
+        from app.services import rating as rating_svc
+
+        monkeypatch.setattr(
+            user_repo, "get_user_by_id",
+            lambda _db, _uid: {"id": _uid, "username": "host"},
+        )
+        rid_orphan = str(uuid4())
+        rows = [{
+            "id": str(uuid4()), "rater_id": rid_orphan, "host_id": "h",
+            "score": 4.0, "review_text": "hi",
+            "created_at": "2030-01-01T00:00:00+00:00",
+        }]
+        monkeypatch.setattr(
+            rating_repo, "list_reviews_for_host",
+            lambda _db, _hid, *, page, page_size: (rows, 1),
+        )
+        # No matching user returned
+        monkeypatch.setattr(user_repo, "get_users_by_ids", lambda _db, _ids: [])
+
+        resp = rating_svc.list_reviews(MagicMock(), "h")
+        assert resp.items[0].rater_username == "unknown"
+
+
+def uuid4_to_uuid(s: str):
+    """Convenience: ReviewListItemResponse.rater_id is UUID; raw rows hold str."""
+    from uuid import UUID
+    return UUID(s)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -110,12 +110,21 @@ def test_user_profiles_and_ratings(client, db):
 # --- Rating reviews (issue #235) ------------------------------------------
 
 def _register_and_login(client, prefix: str) -> tuple[str, str, str]:
-    """Register a fresh user, log in, return (id, email, access_token)."""
+    """Register a fresh user, log in, return (id, email, access_token).
+
+    Raises an explicit assertion if the register call fails so a too-long
+    prefix (username max_length=30 — see app/models/user.py) doesn't
+    cascade into a KeyError on `access_token` later.
+    """
     username, email = build_test_identity(prefix)
-    client.post("/auth/register", json={
+    reg = client.post("/auth/register", json={
         "username": username, "email": email,
         "password": "password123", "date_of_birth": "1990-01-01",
     })
+    assert reg.status_code == 201, (
+        f"Register failed for prefix={prefix!r} (username={username!r}, "
+        f"len={len(username)}): {reg.status_code} {reg.json()}"
+    )
     token = client.post("/auth/login", json={
         "email": email, "password": "password123",
     }).json()["access_token"]
@@ -305,10 +314,12 @@ class TestRatingReviews:
     def test_list_reviews_includes_star_only_with_null_text(self, client, db):
         # Locked decision #1: star-only ratings appear in the list with
         # review_text=null so the count mirrors the aggregate.
+        # Prefixes kept short so build_test_identity stays within the
+        # username max_length=30 (see app/models/user.py).
         host_id, _r1, _host_token, r1_token, event_id = _make_eligible_rater(
-            client, db, host_prefix="revstar-list-host", rater_prefix="revstar-list-r1",
+            client, db, host_prefix="rsl-host", rater_prefix="rsl-r1",
         )
-        r2_id, _, r2_token = _register_and_login(client, "revstar-list-r2")
+        r2_id, _, r2_token = _register_and_login(client, "rsl-r2")
         db.table("attendances").insert({
             "user_id": r2_id, "event_id": event_id, "status": "going",
         }).execute()

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,5 +1,7 @@
 """Integration tests for Users/Profiles/Ratings API."""
 
+import uuid
+
 from tests_support import build_test_identity
 
 
@@ -69,14 +71,14 @@ def test_user_profiles_and_ratings(client, db):
     assert res.status_code == 200
     assert res.json()["can_rate"] is True
 
-    # User rates 4.0
+    # User rates 4.0 — endpoint returns 201 (issue #230 spec)
     res = client.post(f"/users/{host_id}/ratings", headers={"Authorization": f"Bearer {r_token}"}, json={"score": 4.0})
-    assert res.status_code == 200
+    assert res.status_code == 201
     assert float(res.json()["score"]) == 4.0
 
-    # User updates rating to 5.0
+    # User updates rating to 5.0 — upsert path also returns 201
     res = client.post(f"/users/{host_id}/ratings", headers={"Authorization": f"Bearer {r_token}"}, json={"score": 5.0})
-    assert res.status_code == 200
+    assert res.status_code == 201
     assert float(res.json()["score"]) == 5.0
 
     # Check Host profile average
@@ -103,3 +105,294 @@ def test_user_profiles_and_ratings(client, db):
     assert res.status_code == 200
     assert res.json()["email"] == r_email
     assert res.json()["phone_number"] == "+1234567890"
+
+
+# --- Rating reviews (issue #235) ------------------------------------------
+
+def _register_and_login(client, prefix: str) -> tuple[str, str, str]:
+    """Register a fresh user, log in, return (id, email, access_token)."""
+    username, email = build_test_identity(prefix)
+    client.post("/auth/register", json={
+        "username": username, "email": email,
+        "password": "password123", "date_of_birth": "1990-01-01",
+    })
+    token = client.post("/auth/login", json={
+        "email": email, "password": "password123",
+    }).json()["access_token"]
+    user_id = client.get("/auth/me", headers={"Authorization": f"Bearer {token}"}).json()["id"]
+    return user_id, email, token
+
+
+def _make_eligible_rater(client, db, *, host_prefix: str, rater_prefix: str):
+    """Set up a host with an ended event and a rater who attended it.
+
+    Returns (host_id, rater_id, host_token, rater_token, event_id) — the
+    rater is now eligible to rate the host (passed has_attended_ended_event_by_host).
+    """
+    host_id, _, host_token = _register_and_login(client, host_prefix)
+    rater_id, _, rater_token = _register_and_login(client, rater_prefix)
+
+    event_res = db.table("events").insert({
+        "host_id": host_id,
+        "title": f"Ended event {uuid.uuid4().hex[:6]}",
+        "description": "desc",
+        "start_datetime": "2025-01-01T10:00:00Z",
+        "end_datetime": "2025-01-01T12:00:00Z",
+        "visibility": "public",
+        "status": "ended",
+    }).execute()
+    event_id = event_res.data[0]["id"]
+
+    db.table("attendances").insert({
+        "user_id": rater_id, "event_id": event_id, "status": "going",
+    }).execute()
+
+    return host_id, rater_id, host_token, rater_token, event_id
+
+
+class TestRatingReviews:
+    """End-to-end coverage for the new review_text field and /reviews endpoint."""
+
+    def test_rate_with_text_returns_201_and_persists_text(self, client, db):
+        host_id, _rater_id, _host_token, rater_token, _event_id = _make_eligible_rater(
+            client, db, host_prefix="revtxt-host", rater_prefix="revtxt-rater",
+        )
+
+        res = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 4.5, "review_text": "Walk was excellent — leader was clear."},
+        )
+        assert res.status_code == 201, res.json()
+        body = res.json()
+        assert body["review_text"] == "Walk was excellent — leader was clear."
+        assert float(body["score"]) == 4.5
+
+    def test_rate_without_text_returns_201_back_compat(self, client, db):
+        # Star-only rating (existing client behaviour) must keep working.
+        host_id, _rater_id, _host_token, rater_token, _event_id = _make_eligible_rater(
+            client, db, host_prefix="revstar-host", rater_prefix="revstar-rater",
+        )
+
+        res = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 5.0},
+        )
+        assert res.status_code == 201
+        assert res.json()["review_text"] is None
+
+    def test_rate_text_too_long_returns_422(self, client, db):
+        host_id, _, _, rater_token, _ = _make_eligible_rater(
+            client, db, host_prefix="revlong-host", rater_prefix="revlong-rater",
+        )
+        res = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 4.0, "review_text": "x" * 1001},
+        )
+        assert res.status_code == 422
+
+    def test_rate_text_whitespace_only_normalised_to_null(self, client, db):
+        host_id, _, _, rater_token, _ = _make_eligible_rater(
+            client, db, host_prefix="revws-host", rater_prefix="revws-rater",
+        )
+        res = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 3.5, "review_text": "   \n\t  "},
+        )
+        assert res.status_code == 201
+        assert res.json()["review_text"] is None
+
+    def test_rate_upsert_replaces_review_text(self, client, db):
+        # Locked decision #5: upsert overwrites previous text without history.
+        host_id, _, _, rater_token, _ = _make_eligible_rater(
+            client, db, host_prefix="revups-host", rater_prefix="revups-rater",
+        )
+
+        first = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 4.0, "review_text": "First impression"},
+        )
+        assert first.status_code == 201
+        assert first.json()["review_text"] == "First impression"
+
+        second = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 5.0, "review_text": "Better on the second visit"},
+        )
+        assert second.status_code == 201
+        assert second.json()["review_text"] == "Better on the second visit"
+        # Same row, not a duplicate
+        assert second.json()["id"] == first.json()["id"]
+
+    def test_eligibility_unchanged_for_non_attendee(self, client, db):
+        # Even with review_text in the body, a rater who never attended an
+        # ended event by the host still gets 403 (rule unchanged).
+        host_id, _, _host_token = _register_and_login(client, "revelig-host")
+        # Make host actually a host (one ended event, but rater didn't attend)
+        db.table("events").insert({
+            "host_id": host_id, "title": f"H {uuid.uuid4().hex[:6]}",
+            "description": "d", "start_datetime": "2025-01-01T10:00:00Z",
+            "end_datetime": "2025-01-01T12:00:00Z",
+            "visibility": "public", "status": "ended",
+        }).execute()
+        _rater_id, _, rater_token = _register_and_login(client, "revelig-rater")
+
+        res = client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 4.0, "review_text": "I think it was fine"},
+        )
+        assert res.status_code == 403
+
+    def test_list_reviews_unknown_host_returns_404(self, client):
+        # Locked decision #3: unknown host → 404 (matches GET /users/{id}/profile).
+        res = client.get(f"/users/{uuid.uuid4()}/reviews")
+        assert res.status_code == 404
+
+    def test_list_reviews_existing_host_no_ratings_returns_empty(self, client, db):
+        host_id, _, _ = _register_and_login(client, "revempty-host")
+        # Make host eligible to be queried (no ratings yet)
+        db.table("events").insert({
+            "host_id": host_id, "title": f"H {uuid.uuid4().hex[:6]}",
+            "description": "d", "start_datetime": "2025-01-01T10:00:00Z",
+            "end_datetime": "2025-01-01T12:00:00Z",
+            "visibility": "public", "status": "ended",
+        }).execute()
+
+        res = client.get(f"/users/{host_id}/reviews")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+        assert body["total_pages"] == 0
+
+    def test_list_reviews_newest_first_with_text(self, client, db):
+        host_id, _r1, _host_token, r1_token, event_id = _make_eligible_rater(
+            client, db, host_prefix="revlist-host", rater_prefix="revlist-r1",
+        )
+        # Second rater attending the same event
+        r2_id, _, r2_token = _register_and_login(client, "revlist-r2")
+        db.table("attendances").insert({
+            "user_id": r2_id, "event_id": event_id, "status": "going",
+        }).execute()
+
+        # r1 rates first
+        client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {r1_token}"},
+            json={"score": 4.0, "review_text": "First review"},
+        )
+        # r2 rates second (newer created_at)
+        client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {r2_token}"},
+            json={"score": 5.0, "review_text": "Second review"},
+        )
+
+        res = client.get(f"/users/{host_id}/reviews")
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) == 2
+        # Newest-first
+        assert items[0]["review_text"] == "Second review"
+        assert items[1]["review_text"] == "First review"
+
+    def test_list_reviews_includes_star_only_with_null_text(self, client, db):
+        # Locked decision #1: star-only ratings appear in the list with
+        # review_text=null so the count mirrors the aggregate.
+        host_id, _r1, _host_token, r1_token, event_id = _make_eligible_rater(
+            client, db, host_prefix="revstar-list-host", rater_prefix="revstar-list-r1",
+        )
+        r2_id, _, r2_token = _register_and_login(client, "revstar-list-r2")
+        db.table("attendances").insert({
+            "user_id": r2_id, "event_id": event_id, "status": "going",
+        }).execute()
+
+        # r1: star + text
+        client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {r1_token}"},
+            json={"score": 4.0, "review_text": "with text"},
+        )
+        # r2: star only
+        client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {r2_token}"},
+            json={"score": 5.0},
+        )
+
+        res = client.get(f"/users/{host_id}/reviews")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 2
+        assert len(body["items"]) == 2
+        # One has text, one is null
+        texts = sorted([i["review_text"] for i in body["items"]], key=lambda v: (v is None, v))
+        assert texts == ["with text", None]
+
+    def test_list_reviews_includes_rater_username(self, client, db):
+        host_id, rater_id, _host_token, rater_token, _event_id = _make_eligible_rater(
+            client, db, host_prefix="revuname-host", rater_prefix="revuname-rater",
+        )
+        client.post(
+            f"/users/{host_id}/ratings",
+            headers={"Authorization": f"Bearer {rater_token}"},
+            json={"score": 5.0, "review_text": "great"},
+        )
+
+        # Grab the rater's actual username from /auth/me
+        rater_me = client.get(
+            "/auth/me", headers={"Authorization": f"Bearer {rater_token}"},
+        ).json()
+        expected_username = rater_me["username"]
+
+        res = client.get(f"/users/{host_id}/reviews")
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) == 1
+        assert items[0]["rater_id"] == rater_id
+        assert items[0]["rater_username"] == expected_username
+
+    def test_list_reviews_pagination(self, client, db):
+        # 3 raters × same host → page_size=2 yields total_pages=2 with 2+1 items.
+        host_id, _r1, _host_token, r1_token, event_id = _make_eligible_rater(
+            client, db, host_prefix="revpag-host", rater_prefix="revpag-r1",
+        )
+        r2_id, _, r2_token = _register_and_login(client, "revpag-r2")
+        r3_id, _, r3_token = _register_and_login(client, "revpag-r3")
+        for uid in (r2_id, r3_id):
+            db.table("attendances").insert({
+                "user_id": uid, "event_id": event_id, "status": "going",
+            }).execute()
+
+        for tok, score, text in (
+            (r1_token, 5.0, "first"),
+            (r2_token, 4.0, "second"),
+            (r3_token, 3.0, "third"),
+        ):
+            client.post(
+                f"/users/{host_id}/ratings",
+                headers={"Authorization": f"Bearer {tok}"},
+                json={"score": score, "review_text": text},
+            )
+
+        # Page 1
+        p1 = client.get(f"/users/{host_id}/reviews?page=1&page_size=2")
+        assert p1.status_code == 200
+        b1 = p1.json()
+        assert b1["total"] == 3
+        assert b1["total_pages"] == 2
+        assert len(b1["items"]) == 2
+
+        # Page 2
+        p2 = client.get(f"/users/{host_id}/reviews?page=2&page_size=2")
+        assert p2.status_code == 200
+        b2 = p2.json()
+        assert len(b2["items"]) == 1
+        # Combined items match the total
+        assert b1["total"] == b2["total"]


### PR DESCRIPTION
## Summary

Backend portion of [#230](https://github.com/bounswe/bounswe2026group9/issues/230) — closes [#235](https://github.com/bounswe/bounswe2026group9/issues/235).

Adds an optional free-text review next to the star score on host ratings, plus a new paginated reviews-list endpoint so the host profile can surface written reviews newest-first.

- `POST /users/{host_id}/ratings` accepts an optional `review_text` (≤ 1000 chars). Whitespace-only is normalised to `null` in the service layer. Endpoint now returns **201** (issue #230 spec); existing upsert/edit path also returns 201. Eligibility rule unchanged.
- New `GET /users/{host_id}/reviews?page&page_size` — paginated, ordered `created_at DESC, id DESC`. Star-only ratings appear in the list with `review_text=null` so the list count mirrors the aggregate. Unknown host → 404 (mirrors `GET /users/{id}/profile`); existing host with no ratings → 200 + empty items.
- Repeated POSTs from the same rater overwrite the previous text via upsert — same semantics as the existing star-overwrite behaviour, no edit history.

## Locked decisions (confirmed before implementation)

| # | Decision |
|---|---|
| 1 | Star-only ratings appear in the reviews list with `review_text=null` |
| 2 | Reviews live on a separate paginated endpoint (profile stays summary-shaped) |
| 3 | Unknown host → 404; existing host with no ratings → 200 + empty `items` |
| 4 | Whitespace-only `review_text` → normalised to `null` in the service layer |
| 5 | Upsert overwrites previous `review_text` (no edit history) |

## Schema migration (must be applied to Supabase before this code runs)

[`backend/sql/014_add_rating_review_text.sql`](backend/sql/014_add_rating_review_text.sql) — single ALTER TABLE adding nullable `review_text TEXT` with a `CHECK (char_length ≤ 1000)` and a `(host_id, created_at DESC)` index for pagination. Existing rows are unaffected (`review_text` defaults to NULL). **Already applied to the dev Supabase before opening this PR.**

## Implementation notes

- `list_reviews_for_host` uses a deliberate count + page two-query pattern rather than PostgREST FK embedding (`users!ratings_rater_id_fkey(...)`) — the embed name is environment-specific and would silently miss rater info if Supabase's FK relationship name differed. Username resolution lives in the service via `user_repo.get_users_by_ids`.
- Whitespace normalisation in `services/rating._normalise_review_text` keeps the DB free of sham reviews; placeholder rendering on the frontend stays unambiguous.
- The existing autouse `cleanup_test_users` fixture from `conftest.py` is overridden to a no-op inside `test_reviews_unit.py` so the unit shard is truly DB-free; running the file locally without Supabase env now no longer errors at teardown.

## Test plan

- [ ] CI lint (ruff): clean locally (`uv run ruff check .`).
- [ ] CI `unit-fast` shard exercises [`tests/test_reviews_unit.py`](backend/tests/test_reviews_unit.py): 32 cases covering Pydantic schemas (1000-char boundary, back-compat star-only payload), `_normalise_review_text` matrix, repo read/write contracts (count+page order, upsert payload), service-layer pinning of `rate_host` (trim + repo payload + self-rating short-circuit) and `list_reviews` (404 unknown host / 200 empty / pagination math / username mapping / orphan-rater fallback). **32 passed locally.**
- [ ] CI `auth-core` shard exercises [`tests/test_users.py`](backend/tests/test_users.py)'s `TestRatingReviews` class: 12 integration cases covering `201` with text, `201` without text (back-compat), `422` length validation, whitespace-normalisation through the API, upsert overwrite, eligibility unchanged for non-attendee, unknown-host `404`, existing-host empty `200`, newest-first ordering, star-only inclusion in the list, `rater_username` surfacing, and 3-row pagination at `page_size=2`.
- [ ] Manual smoke (post-deploy): POST a rating with text, GET `/users/{id}/reviews`, confirm the row appears with the rater's username and the timestamp matches.

## Notes for the reviewer (@canemirbora4)

- Existing `test_users.py::test_user_profiles_and_ratings` had two assertions on `200` for the rating endpoint (lines 74, 79); both updated to `201` to match the new contract. No behaviour-affecting changes there.
- Frontend (#230 web/mobile tasks) — backend exposes:
  - new optional `review_text` on `POST /users/{id}/ratings` request and response,
  - new `GET /users/{id}/reviews` paginated endpoint with `rater_username`, `score`, `review_text` (nullable), `created_at`.
  - Star-only ratings appear in the list with `review_text=null` — the frontend should render a "No written review" placeholder for those rows (decision #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)