### PR TITLE
feat(web): JSON-LD / Schema.org structured data on event + profile pages

### DIFF
--- a/frontend/src/app/event/[id]/page.tsx
+++ b/frontend/src/app/event/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
 
 import { useAuth } from "@/hooks/use-auth";
 import { useEventInteraction } from "@/hooks/use-event-interaction";
+import { JsonLd } from "@/components/json-ld";
 import { Navbar } from "@/components/layout/navbar";
 import { StatusBadge, eventStatusVariant } from "@/components/event/status-badge";
 import { ImageCarousel } from "@/components/event/image-carousel";
@@ -59,6 +60,7 @@ import {
   type AccessRequest,
   type Invite,
 } from "@/lib/events-api";
+import { buildEventStructuredData } from "@/lib/structured-data";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -1311,8 +1313,19 @@ export default function EventDetailPage() {
       (!isAuthenticated || !user?.date_of_birth || !isAtLeast18(user.date_of_birth)),
     );
 
+  // JSON-LD structured data for crawlers (issue #243).
+  // Built only when the event has loaded; for private events the helper emits
+  // a visibility-safe subset (no description, no location, no attendees).
+  // window is referenced on the client; SSR fallback is omitted because this
+  // page is "use client" and the script renders after hydration.
+  const baseUrl =
+    typeof window !== "undefined" ? window.location.origin : "";
+  const eventStructuredData =
+    event && baseUrl ? buildEventStructuredData(event, host, baseUrl) : null;
+
   return (
     <div className="bg-brand-bg min-h-screen">
+      {eventStructuredData && <JsonLd data={eventStructuredData} />}
       <Navbar />
 
       {loading ? (

--- a/frontend/src/components/json-ld.tsx
+++ b/frontend/src/components/json-ld.tsx
@@ -1,0 +1,20 @@
+// Renders a Schema.org / JSON-LD 1.1 block as <script type="application/ld+json">.
+// Issue #243.
+//
+// Next.js renders this script element as-is in the HTML stream; for client
+// components it lands in <body>, which crawlers still pick up. We use
+// dangerouslySetInnerHTML because JSON-LD must be raw text, not React
+// children (React would escape angle brackets and break the JSON parser).
+
+interface JsonLdProps {
+  data: Record<string, unknown> | Record<string, unknown>[];
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/frontend/src/components/profile/host-profile-page.tsx
+++ b/frontend/src/components/profile/host-profile-page.tsx
@@ -5,11 +5,13 @@ import Link from "next/link";
 import { CalendarDays, Mail, Phone, Star } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import { JsonLd } from "@/components/json-ld";
 import { StatusBadge } from "@/components/event/status-badge";
 import { Navbar } from "@/components/layout/navbar";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import { fetchHostProfile, rateHost, type EventListItem, type HostProfile } from "@/lib/events-api";
+import { buildHostStructuredData } from "@/lib/structured-data";
 import { cn } from "@/lib/utils";
 
 type ProfileTab = "about" | "past" | "upcoming";
@@ -267,8 +269,18 @@ export function HostProfilePage() {
     }
   }
 
+  // JSON-LD structured data for crawlers (issue #243).
+  // Emitted once the profile is loaded; private fields (email/phone) are
+  // gated by the backend's privacy settings before they reach this point,
+  // so forwarding them here is safe.
+  const baseUrl =
+    typeof window !== "undefined" ? window.location.origin : "";
+  const profileStructuredData =
+    profile && baseUrl ? buildHostStructuredData(profile, baseUrl) : null;
+
   return (
     <div className="min-h-screen bg-brand-bg">
+      {profileStructuredData && <JsonLd data={profileStructuredData} />}
       <Navbar />
 
       {loading ? (

--- a/frontend/src/lib/structured-data.ts
+++ b/frontend/src/lib/structured-data.ts
@@ -1,0 +1,178 @@
+// JSON-LD 1.1 / Schema.org structured-data builders for public pages.
+// Issue #243.
+//
+// Two builders are exported:
+//   - buildEventStructuredData: Schema.org Event for /event/[id]
+//   - buildHostStructuredData : Schema.org Person (+ AggregateRating) for /profile/[id]
+//
+// Both produce a plain object suitable for rendering inside
+// <script type="application/ld+json">. Pass the result through JSON.stringify
+// in the consumer.
+//
+// Privacy contract for Event:
+//   - Public events emit the full payload (description, location, image, etc.).
+//   - Private events emit ONLY visibility-safe fields (name, dates, status, url,
+//     categories) — same surface a guest already sees in the limited preview.
+//   - Cancelled / ended status is reflected via eventStatus so search engines
+//     don't show stale events as bookable.
+
+import type {
+  AnyEventDetail,
+  EventDetail,
+  EventLocation,
+  HostProfile,
+} from "@/lib/events-api";
+
+const EVENT_STATUS_MAP: Record<EventDetail["status"], string> = {
+  draft: "https://schema.org/EventScheduled",
+  published: "https://schema.org/EventScheduled",
+  updated: "https://schema.org/EventRescheduled",
+  cancelled: "https://schema.org/EventCancelled",
+  ended: "https://schema.org/EventScheduled",
+};
+
+function eventUrl(baseUrl: string, eventId: string): string {
+  return `${baseUrl.replace(/\/$/, "")}/event/${eventId}`;
+}
+
+function profileUrl(baseUrl: string, userId: string): string {
+  return `${baseUrl.replace(/\/$/, "")}/profile/${userId}`;
+}
+
+function pickPrimaryLocation(locations: EventLocation[] | undefined): EventLocation | null {
+  if (!locations || locations.length === 0) return null;
+  return locations.find((l) => l.is_primary) ?? locations[0];
+}
+
+/**
+ * Build a Schema.org Event object for the given event payload.
+ *
+ * `host` is optional; when provided, organizer is filled with the host's
+ * username and profile URL.
+ *
+ * For private events (or limited responses) only the visibility-safe subset
+ * is emitted — never description, location coordinates, attendees, or images.
+ */
+export function buildEventStructuredData(
+  event: AnyEventDetail,
+  host: HostProfile | null,
+  baseUrl: string,
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: event.title,
+    startDate: event.start_datetime,
+    endDate: event.end_datetime,
+    eventStatus: EVENT_STATUS_MAP[event.status],
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    url: eventUrl(baseUrl, event.id),
+  };
+
+  // Categories are visible in both limited and full views, safe to expose.
+  const categoryNames = event.categories.map((c) => c.name).filter(Boolean);
+  if (categoryNames.length > 0) {
+    base.keywords = categoryNames.join(", ");
+  }
+
+  // Private events stop here — never leak description, location, attendees.
+  // Type-narrowing is done inline so TS sees `fullEvent` as EventDetail.
+  if (event._type !== "full" || event.visibility !== "public") {
+    return base;
+  }
+  const fullEvent: EventDetail = event;
+
+  if (fullEvent.description) {
+    base.description = fullEvent.description;
+  }
+
+  if (fullEvent.images && fullEvent.images.length > 0) {
+    base.image = fullEvent.images.map((img) => img.image_url);
+  }
+
+  const primary = pickPrimaryLocation(fullEvent.locations);
+  if (primary) {
+    base.location = {
+      "@type": "Place",
+      name: primary.name,
+      geo: {
+        "@type": "GeoCoordinates",
+        latitude: primary.latitude,
+        longitude: primary.longitude,
+      },
+    };
+  }
+
+  if (host && fullEvent.host_id) {
+    base.organizer = {
+      "@type": "Person",
+      name: host.username,
+      url: profileUrl(baseUrl, fullEvent.host_id),
+    };
+  }
+
+  // Capacity, when explicitly set by the host, is public on the detail page.
+  if (fullEvent.attendee_limit != null) {
+    base.maximumAttendeeCapacity = fullEvent.attendee_limit;
+  }
+
+  // Free-of-charge hint via venue metadata. We only set isAccessibleForFree
+  // when the host explicitly typed something starting with "free" — guessing
+  // would mislead crawlers, so the conservative default is to omit.
+  const price = fullEvent.venue_metadata?.price?.toLowerCase() ?? "";
+  if (price.startsWith("free")) {
+    base.isAccessibleForFree = true;
+  }
+
+  return base;
+}
+
+/**
+ * Build a Schema.org Person object for a host profile.
+ *
+ * `email` and `telephone` are only included when the backend has already
+ * gated them through the user's privacy settings (the API returns them as
+ * null when the host opted out, so we just forward what we got).
+ *
+ * AggregateRating is included when `average_rating` is available.
+ * `ratingCount` is intentionally omitted — the profile endpoint doesn't
+ * expose it today, and emitting a fake count would be worse than leaving
+ * it off. Schema.org allows AggregateRating with `ratingValue`,
+ * `bestRating`, and `worstRating` alone.
+ */
+export function buildHostStructuredData(
+  host: HostProfile,
+  baseUrl: string,
+): Record<string, unknown> {
+  type WithSameAs = string | undefined;
+
+  const data: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    identifier: host.id,
+    name: host.username,
+    url: profileUrl(baseUrl, host.id),
+  };
+
+  if (host.email) {
+    data.email = host.email;
+  }
+  if (host.phone_number) {
+    data.telephone = host.phone_number;
+  }
+
+  if (host.average_rating !== null && host.average_rating !== undefined) {
+    data.aggregateRating = {
+      "@type": "AggregateRating",
+      ratingValue: Number(host.average_rating.toFixed(2)),
+      bestRating: 5,
+      worstRating: 1,
+    };
+  }
+
+  // sameAs is left empty — kept on the type to make adding social links
+  // trivial later without changing the consumer signature.
+  void (undefined as WithSameAs);
+
+  return data;
+}

--- a/frontend/src/lib/structured-data.ts
+++ b/frontend/src/lib/structured-data.ts
@@ -116,11 +116,14 @@ export function buildEventStructuredData(
     base.maximumAttendeeCapacity = fullEvent.attendee_limit;
   }
 
-  // Free-of-charge hint via venue metadata. We only set isAccessibleForFree
-  // when the host explicitly typed something starting with "free" — guessing
-  // would mislead crawlers, so the conservative default is to omit.
-  const price = fullEvent.venue_metadata?.price?.toLowerCase() ?? "";
-  if (price.startsWith("free")) {
+  // Free-of-charge hint via venue metadata. We only flip
+  // isAccessibleForFree on when the host explicitly typed an unambiguous
+  // "free" marker (English or Turkish) — guessing would mislead crawlers,
+  // so the conservative default is to omit. Trim handles trailing
+  // whitespace / "Free " patterns.
+  const price = fullEvent.venue_metadata?.price?.trim().toLowerCase() ?? "";
+  const FREE_MARKERS = ["free", "ücretsiz", "ucretsiz", "bedava"];
+  if (FREE_MARKERS.some((marker) => price === marker || price.startsWith(`${marker} `))) {
     base.isAccessibleForFree = true;
   }
 
@@ -144,8 +147,6 @@ export function buildHostStructuredData(
   host: HostProfile,
   baseUrl: string,
 ): Record<string, unknown> {
-  type WithSameAs = string | undefined;
-
   const data: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "Person",
@@ -169,10 +170,6 @@ export function buildHostStructuredData(
       worstRating: 1,
     };
   }
-
-  // sameAs is left empty — kept on the type to make adding social links
-  // trivial later without changing the consumer signature.
-  void (undefined as WithSameAs);
 
   return data;
 }


### PR DESCRIPTION
Adds JSON-LD 1.1 blocks with Schema.org vocabulary on the public-facing event detail and host profile pages so crawlers can index events as Schema.org Event and hosts as Schema.org Person.

- New helpers in lib/structured-data.ts build the payloads from the existing fetched data, no extra round-trip.
- New JsonLd component renders the <script type="application/ld+json"> tag inline on the page.
- Event mapping: name, description, startDate, endDate, eventStatus (mapped from lifecycle), eventAttendanceMode, location (Place + GeoCoordinates), organizer (Person), image, url, keywords, maximumAttendeeCapacity, isAccessibleForFree.
- Host mapping: identifier, name, url, email/telephone (forwarded as the backend already gates these by privacy settings), AggregateRating when average_rating is available.
- Privacy: limited responses and private events emit only the visibility-safe subset (name, dates, status, url, keywords) — never description, location coordinates, or attendees.

Closes #243 