### PR TITLE
docs(api): formalize OpenAPI 3.1 contract for issue #249

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,9 +17,131 @@ from app.routers import (
     users,
 )
 
+API_DESCRIPTION = """
+Backend API for **Social Event Mapper** — a platform for discovering, hosting,
+and attending social events.
+
+The API follows the **OpenAPI 3.1** specification (FastAPI ≥ 0.100 emits
+`openapi: 3.1.0` by default). Both the web and mobile clients are generated
+or hand-written against this contract, so the schema is the source of truth.
+
+## Authentication
+
+Most endpoints require a short-lived **bearer access token** in the
+`Authorization` header:
+
+```
+Authorization: Bearer <access_token>
+```
+
+Access tokens are obtained from `POST /auth/register`, `POST /auth/login`,
+`POST /auth/refresh`, or the Google OAuth flow under `/auth/google`. They are
+rotated using a long-lived refresh token, which the server stores in a
+`HttpOnly` cookie (`sem_refresh_token`) — clients should not read or store
+that cookie themselves.
+
+A small number of read-only endpoints (event discovery and event detail)
+accept an *optional* bearer token: anonymous callers get a public view,
+authenticated callers may get an enriched view (e.g. private events they are
+invited to).
+
+## Conventions
+
+* **Error envelope** — every non-2xx response returns
+  `{ "detail": "<message>" }`. Validation failures (HTTP 422) return
+  `{ "detail": [ { "loc": [...], "msg": "...", "type": "..." } ] }` per
+  Pydantic's standard format.
+* **Pagination** — list endpoints accept `page` (≥ 1, default 1) and
+  `page_size` (1–100, default 20). Responses include `total` and the page
+  metadata.
+* **Identifiers** — all resource IDs are UUIDs.
+* **Timestamps** — ISO 8601 in UTC.
+* **Rate limiting** — auth endpoints are throttled per IP; exceeding the
+  limit returns HTTP 429 with a `Retry-After` header.
+"""
+
+TAGS_METADATA = [
+    {
+        "name": "auth",
+        "description": (
+            "Registration, login, token refresh/rotation, logout, email "
+            "verification, and Google OAuth. Sets the `sem_refresh_token` "
+            "HttpOnly cookie; access tokens are returned in the response body."
+        ),
+    },
+    {
+        "name": "events",
+        "description": (
+            "Event lifecycle: discovery (search/filter/sort), detail view, "
+            "create / update / status change / delete, and event images. "
+            "Discovery accepts an optional bearer token for visibility-aware "
+            "results."
+        ),
+    },
+    {
+        "name": "categories",
+        "description": (
+            "Predefined and user-suggested categories used to tag events. "
+            "Custom categories require admin approval before they appear in "
+            "discovery filters."
+        ),
+    },
+    {
+        "name": "comments",
+        "description": "Threaded comments on a specific event.",
+    },
+    {
+        "name": "invites",
+        "description": (
+            "Private-event invitations and access requests — host issues "
+            "invites or approves/denies guest access requests."
+        ),
+    },
+    {
+        "name": "notifications",
+        "description": (
+            "Per-user notification feed: list, unread count, mark single / "
+            "all as read."
+        ),
+    },
+    {
+        "name": "bookmarks",
+        "description": "Save / unsave an event for the authenticated user.",
+    },
+    {
+        "name": "attendances",
+        "description": (
+            "Per-user attendance status on an event "
+            "(`going` / `interested` / `not_going`)."
+        ),
+    },
+    {
+        "name": "users",
+        "description": (
+            "Profile read/update, host ratings & reviews, and the "
+            "authenticated user's bookmarks list."
+        ),
+    },
+]
+
+
 app = FastAPI(
     title="Social Event Mapper API",
     version="0.1.0",
+    summary="OpenAPI 3.1 contract for the Social Event Mapper backend.",
+    description=API_DESCRIPTION,
+    openapi_tags=TAGS_METADATA,
+    contact={
+        "name": "bounswe2026group9",
+        "url": "https://github.com/bounswe/bounswe2026group9",
+    },
+    license_info={
+        "name": "MIT",
+        "url": "https://github.com/bounswe/bounswe2026group9/blob/main/LICENSE",
+    },
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
 )
 
 # --- Per-endpoint rate limiting ---
@@ -47,7 +169,15 @@ app.include_router(attendances.router)
 app.include_router(users.router)
 
 
-@app.get("/health")
+@app.get(
+    "/health",
+    tags=["meta"],
+    summary="Liveness & DB connectivity probe",
+    description=(
+        "Used by the container platform's health check. Returns `status=ok` "
+        "and a `database` field of `connected` or `error`."
+    ),
+)
 def health_check():
     from app.database import get_supabase
     try:

--- a/backend/app/models/errors.py
+++ b/backend/app/models/errors.py
@@ -1,0 +1,65 @@
+"""Standard error response schemas used across the OpenAPI spec.
+
+FastAPI raises ``HTTPException`` with a ``detail`` payload for all error
+cases. Documenting that shape here gives every client a single, predictable
+error contract instead of an opaque ``string``.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    """Uniform error envelope returned for non-2xx responses."""
+
+    detail: str = Field(
+        description="Human-readable explanation of the error.",
+        examples=["Invalid email or password"],
+    )
+
+
+class ValidationErrorItem(BaseModel):
+    loc: list[str | int] = Field(
+        description="Path to the offending field, e.g. ['body', 'email'].",
+        examples=[["body", "email"]],
+    )
+    msg: str = Field(
+        description="Validation message.",
+        examples=["value is not a valid email address"],
+    )
+    type: str = Field(
+        description="Pydantic error type.",
+        examples=["value_error.email"],
+    )
+
+
+class ValidationErrorResponse(BaseModel):
+    """Pydantic validation failure (HTTP 422)."""
+
+    detail: list[ValidationErrorItem]
+
+
+# Reusable response dictionaries for ``responses=`` on endpoints.
+# Compose with ``{**AUTH_RESPONSES, ...}``  per-endpoint.
+COMMON_RESPONSES = {
+    422: {"model": ValidationErrorResponse, "description": "Request validation failed."},
+}
+
+AUTH_RESPONSES = {
+    401: {"model": ErrorResponse, "description": "Missing, invalid, or expired access token."},
+}
+
+FORBIDDEN_RESPONSE = {
+    403: {"model": ErrorResponse, "description": "Authenticated but not allowed to perform this action."},
+}
+
+NOT_FOUND_RESPONSE = {
+    404: {"model": ErrorResponse, "description": "Resource not found."},
+}
+
+CONFLICT_RESPONSE = {
+    409: {"model": ErrorResponse, "description": "Conflict with current resource state (e.g. duplicate)."},
+}
+
+RATE_LIMIT_RESPONSE = {
+    429: {"model": ErrorResponse, "description": "Rate limit exceeded — retry later."},
+}

--- a/backend/app/routers/attendances.py
+++ b/backend/app/routers/attendances.py
@@ -7,13 +7,21 @@ from fastapi import APIRouter, Depends, status
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
 from app.models.attendance import AttendanceResponse, AttendanceStatusRequest
+from app.models.errors import AUTH_RESPONSES, NOT_FOUND_RESPONSE
 from app.models.user import MessageResponse
 from app.services.attendance import remove_attendance, set_attendance
 
 router = APIRouter(prefix="/events/{event_id}/attendance", tags=["attendances"])
 
 
-@router.post("", status_code=status.HTTP_200_OK, response_model=AttendanceResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=AttendanceResponse,
+    summary="Set attendance status",
+    description="Idempotent — repeating with the same status is a no-op.",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
 def set_attendance_endpoint(
     event_id: UUID,
     body: AttendanceStatusRequest,
@@ -23,7 +31,12 @@ def set_attendance_endpoint(
     return set_attendance(db, str(event_id), user_id, body.status)
 
 
-@router.delete("", response_model=MessageResponse)
+@router.delete(
+    "",
+    response_model=MessageResponse,
+    summary="Clear attendance status",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
 def remove_attendance_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,6 +4,12 @@ from starlette.responses import RedirectResponse
 from app.config import settings
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
+from app.models.errors import (
+    AUTH_RESPONSES,
+    CONFLICT_RESPONSE,
+    NOT_FOUND_RESPONSE,
+    RATE_LIMIT_RESPONSE,
+)
 from app.models.user import (
     AuthResponse,
     MessageResponse,
@@ -77,7 +83,18 @@ def _user_response(user: dict) -> UserResponse:
 
 # --- Register ---
 
-@router.post("/register", status_code=201)
+@router.post(
+    "/register",
+    status_code=201,
+    response_model=AuthResponse,
+    summary="Register a new user",
+    description=(
+        "Creates a local-auth user, sets the refresh-token cookie, and "
+        "returns an access token. A verification email is sent in the "
+        "background; `email_sent=false` means SMTP is unconfigured."
+    ),
+    responses={**CONFLICT_RESPONSE, **RATE_LIMIT_RESPONSE},
+)
 @limiter.limit("5/minute")
 def register(request: Request, body: UserRegisterRequest, response: Response, background_tasks: BackgroundTasks):
     db = get_supabase()
@@ -120,7 +137,17 @@ def register(request: Request, body: UserRegisterRequest, response: Response, ba
 
 # --- Login ---
 
-@router.post("/login", response_model=AuthResponse)
+@router.post(
+    "/login",
+    response_model=AuthResponse,
+    summary="Log in with email + password",
+    description=(
+        "Returns an access token and sets the `sem_refresh_token` HttpOnly "
+        "cookie. Repeated failures lock the account; Google-only accounts "
+        "must use `/auth/google`."
+    ),
+    responses={**AUTH_RESPONSES, **RATE_LIMIT_RESPONSE},
+)
 @limiter.limit("10/minute")
 def login(request: Request, body: UserLoginRequest, response: Response):
     db = get_supabase()
@@ -170,7 +197,16 @@ def login(request: Request, body: UserLoginRequest, response: Response):
 
 # --- Refresh ---
 
-@router.post("/refresh", response_model=AuthResponse)
+@router.post(
+    "/refresh",
+    response_model=AuthResponse,
+    summary="Rotate access + refresh tokens",
+    description=(
+        "Reads the refresh token from the body or the `sem_refresh_token` "
+        "cookie, rotates it, and returns a fresh access token."
+    ),
+    responses={**AUTH_RESPONSES},
+)
 def refresh(request: Request, response: Response, body: RefreshTokenRequest = None):
     # Get token from body or cookie
     token = None
@@ -207,7 +243,12 @@ def refresh(request: Request, response: Response, body: RefreshTokenRequest = No
 
 # --- Logout ---
 
-@router.post("/logout", response_model=MessageResponse)
+@router.post(
+    "/logout",
+    response_model=MessageResponse,
+    summary="Log out",
+    description="Revokes the refresh token and clears the cookie. Idempotent.",
+)
 def logout(request: Request, response: Response, body: RefreshTokenRequest = None):
     token = None
     if body and body.refresh_token:
@@ -224,7 +265,12 @@ def logout(request: Request, response: Response, body: RefreshTokenRequest = Non
 
 # --- Me ---
 
-@router.get("/me", response_model=UserResponse)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Authenticated user's profile",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
 def me(user_id: str = Depends(get_current_user_id)):
     db = get_supabase()
     result = db.table("users").select(USER_SAFE_COLS).eq("id", user_id).execute()
@@ -235,7 +281,12 @@ def me(user_id: str = Depends(get_current_user_id)):
 
 # --- Email Verification ---
 
-@router.get("/verify-email", response_model=MessageResponse)
+@router.get(
+    "/verify-email",
+    response_model=MessageResponse,
+    summary="Verify email via token",
+    description="Token is delivered in the verification email link.",
+)
 def verify_email(token: str):
     user_id = validate_verification_token(token)
     if not user_id:
@@ -246,7 +297,12 @@ def verify_email(token: str):
     return MessageResponse(message="Email verified successfully")
 
 
-@router.post("/resend-verification", response_model=MessageResponse)
+@router.post(
+    "/resend-verification",
+    response_model=MessageResponse,
+    summary="Resend verification email",
+    responses={**AUTH_RESPONSES, **RATE_LIMIT_RESPONSE},
+)
 @limiter.limit("3/minute")
 def resend_verification(request: Request, background_tasks: BackgroundTasks, user_id: str = Depends(get_current_user_id)):
     db = get_supabase()
@@ -269,7 +325,14 @@ def resend_verification(request: Request, background_tasks: BackgroundTasks, use
 OAUTH_STATE_COOKIE = "oauth_state"
 
 
-@router.get("/google")
+@router.get(
+    "/google",
+    summary="Start Google OAuth flow",
+    description=(
+        "Redirects the browser to Google's consent screen. `mode` is "
+        "either `login` or `signup` and is round-tripped through state."
+    ),
+)
 def google_auth(mode: str = "login"):
     """Redirect to Google OAuth. mode: 'signup' or 'login'."""
     state = generate_oauth_state()
@@ -287,7 +350,15 @@ def google_auth(mode: str = "login"):
     return redirect
 
 
-@router.get("/google/callback")
+@router.get(
+    "/google/callback",
+    summary="Google OAuth callback",
+    description=(
+        "Validates the state cookie, exchanges the code for Google tokens, "
+        "links or creates the local user, sets the refresh-token cookie, "
+        "and redirects to the frontend `/auth/callback` page."
+    ),
+)
 def google_callback(
     code: str,
     state: str,

--- a/backend/app/routers/bookmarks.py
+++ b/backend/app/routers/bookmarks.py
@@ -7,13 +7,20 @@ from fastapi import APIRouter, Depends, status
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
 from app.models.bookmark import BookmarkResponse
+from app.models.errors import AUTH_RESPONSES, CONFLICT_RESPONSE, NOT_FOUND_RESPONSE
 from app.models.user import MessageResponse
 from app.services.bookmark import create_bookmark, remove_bookmark
 
 router = APIRouter(prefix="/events/{event_id}/bookmark", tags=["bookmarks"])
 
 
-@router.post("", status_code=status.HTTP_201_CREATED, response_model=BookmarkResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=BookmarkResponse,
+    summary="Bookmark an event",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE, **CONFLICT_RESPONSE},
+)
 def create_bookmark_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),
@@ -22,7 +29,12 @@ def create_bookmark_endpoint(
     return create_bookmark(db, str(event_id), user_id)
 
 
-@router.delete("", response_model=MessageResponse)
+@router.delete(
+    "",
+    response_model=MessageResponse,
+    summary="Remove an event bookmark",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
 def remove_bookmark_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),

--- a/backend/app/routers/categories.py
+++ b/backend/app/routers/categories.py
@@ -4,13 +4,20 @@ from fastapi import APIRouter, Depends, Query, status
 
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
+from app.models.errors import AUTH_RESPONSES, CONFLICT_RESPONSE
 from app.models.event import CategoryCreateRequest, CategoryResponse
 from app.services.category import create_custom_category, list_categories
 
 router = APIRouter(prefix="/categories", tags=["categories"])
 
 
-@router.get("", response_model=list[CategoryResponse])
+@router.get(
+    "",
+    response_model=list[CategoryResponse],
+    summary="List approved categories",
+    description="Returns predefined plus admin-approved custom categories. "
+                "`search` matches on name (case-insensitive).",
+)
 def list_categories_endpoint(
     search: str | None = Query(default=None, min_length=1),
 ):
@@ -18,7 +25,15 @@ def list_categories_endpoint(
     return list_categories(db, search)
 
 
-@router.post("", status_code=status.HTTP_201_CREATED, response_model=CategoryResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CategoryResponse,
+    summary="Suggest a custom category",
+    description="Created with `is_approved=false`; appears in discovery only "
+                "after admin approval.",
+    responses={**AUTH_RESPONSES, **CONFLICT_RESPONSE},
+)
 def create_category_endpoint(
     body: CategoryCreateRequest,
     user_id: str = Depends(get_current_user_id),

--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Query, status
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
 from app.models.comment import CommentCreateRequest, CommentListResponse, CommentResponse
+from app.models.errors import AUTH_RESPONSES, FORBIDDEN_RESPONSE, NOT_FOUND_RESPONSE
 from app.models.user import MessageResponse
 from app.services.comment import (
     create_comment,
@@ -17,7 +18,13 @@ from app.services.comment import (
 router = APIRouter(prefix="/events/{event_id}/comments", tags=["comments"])
 
 
-@router.post("", status_code=status.HTTP_201_CREATED, response_model=CommentResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CommentResponse,
+    summary="Post a comment on an event",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
 def create_comment_endpoint(
     event_id: UUID,
     body: CommentCreateRequest,
@@ -27,7 +34,12 @@ def create_comment_endpoint(
     return create_comment(db, str(event_id), user_id, body)
 
 
-@router.get("", response_model=CommentListResponse)
+@router.get(
+    "",
+    response_model=CommentListResponse,
+    summary="List comments for an event",
+    responses={**NOT_FOUND_RESPONSE},
+)
 def list_comments_endpoint(
     event_id: UUID,
     page: int = Query(default=1, ge=1),
@@ -37,7 +49,13 @@ def list_comments_endpoint(
     return list_comments(db, str(event_id), page=page, page_size=page_size)
 
 
-@router.delete("/{comment_id}", response_model=MessageResponse)
+@router.delete(
+    "/{comment_id}",
+    response_model=MessageResponse,
+    summary="Delete a comment",
+    description="Author or event host only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def delete_comment_endpoint(
     event_id: UUID,
     comment_id: UUID,

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -6,6 +6,12 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, UploadFile
 
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
+from app.models.errors import (
+    AUTH_RESPONSES,
+    CONFLICT_RESPONSE,
+    FORBIDDEN_RESPONSE,
+    NOT_FOUND_RESPONSE,
+)
 from app.models.event import (
     EventCreateRequest,
     EventDetailResponse,
@@ -64,7 +70,17 @@ def _optional_user_id(authorization: str | None = Header(default=None)) -> str |
         ) from e
 
 
-@router.get("", response_model=EventListResponse)
+@router.get(
+    "",
+    response_model=EventListResponse,
+    summary="Discover events",
+    description=(
+        "Paginated list of `published`/`updated` events whose `end_datetime` "
+        "is in the future. Supports text search, category, and a temporal "
+        "quick filter. Optional bearer token: anonymous callers get the "
+        "public view."
+    ),
+)
 def list_events_endpoint(
     search: str | None = Query(default=None, max_length=200),
     category_id: UUID | None = Query(default=None),
@@ -85,7 +101,18 @@ def list_events_endpoint(
     )
 
 
-@router.post("", status_code=status.HTTP_201_CREATED, response_model=EventDetailResponse)
+@router.post(
+    "",
+    status_code=status.HTTP_201_CREATED,
+    response_model=EventDetailResponse,
+    summary="Create an event",
+    description=(
+        "Create a new event with locations, categories, optional venue "
+        "metadata, equipment list, and itinerary segments — all in one "
+        "atomic transaction."
+    ),
+    responses={**AUTH_RESPONSES, **CONFLICT_RESPONSE},
+)
 def create_event_endpoint(
     body: EventCreateRequest,
     user_id: str = Depends(get_current_user_id),
@@ -94,7 +121,18 @@ def create_event_endpoint(
     return create_event(db, user_id, body)
 
 
-@router.get("/{event_id}", response_model=EventDetailResponse | EventLimitedResponse)
+@router.get(
+    "/{event_id}",
+    response_model=EventDetailResponse | EventLimitedResponse,
+    summary="Get event detail",
+    description=(
+        "Returns the full event payload for callers with access. "
+        "For private events the caller does not have access to, returns a "
+        "limited subset (`EventLimitedResponse`) — title, host, status, "
+        "and the public preview fields only."
+    ),
+    responses={**NOT_FOUND_RESPONSE},
+)
 def get_event_endpoint(
     event_id: UUID,
     user_id: str | None = Depends(_optional_user_id),
@@ -103,7 +141,14 @@ def get_event_endpoint(
     return get_event_detail(db, str(event_id), user_id)
 
 
-@router.put("/{event_id}", response_model=EventDetailResponse)
+@router.put(
+    "/{event_id}",
+    response_model=EventDetailResponse,
+    summary="Update an event",
+    description="Host-only. Replaces event fields and any nested collections "
+                "supplied in the body atomically.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def update_event_endpoint(
     event_id: UUID,
     body: EventUpdateRequest,
@@ -113,7 +158,16 @@ def update_event_endpoint(
     return update_event(db, str(event_id), user_id, body)
 
 
-@router.patch("/{event_id}/status", response_model=EventDetailResponse)
+@router.patch(
+    "/{event_id}/status",
+    response_model=EventDetailResponse,
+    summary="Change event status",
+    description=(
+        "Host-only. Transition the event between `draft`, `published`, "
+        "`updated`, and `cancelled` per the lifecycle rules."
+    ),
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def change_event_status_endpoint(
     event_id: UUID,
     body: StatusChangeRequest,
@@ -123,7 +177,14 @@ def change_event_status_endpoint(
     return change_event_status(db, str(event_id), user_id, body.status)
 
 
-@router.delete("/{event_id}", status_code=status.HTTP_200_OK, response_model=MessageResponse)
+@router.delete(
+    "/{event_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=MessageResponse,
+    summary="Delete an event",
+    description="Host-only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def delete_event_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),
@@ -133,7 +194,15 @@ def delete_event_endpoint(
     return MessageResponse(message="Event deleted successfully")
 
 
-@router.post("/{event_id}/images", status_code=status.HTTP_201_CREATED, response_model=EventImageResponse)
+@router.post(
+    "/{event_id}/images",
+    status_code=status.HTTP_201_CREATED,
+    response_model=EventImageResponse,
+    summary="Upload an event image",
+    description="Host-only. `multipart/form-data` upload; max size and "
+                "MIME-type rules are enforced server-side.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def upload_image_endpoint(
     event_id: UUID,
     file: UploadFile,
@@ -143,7 +212,13 @@ def upload_image_endpoint(
     return upload_event_image(db, str(event_id), user_id, file)
 
 
-@router.delete("/{event_id}/images/{image_id}", response_model=MessageResponse)
+@router.delete(
+    "/{event_id}/images/{image_id}",
+    response_model=MessageResponse,
+    summary="Delete an event image",
+    description="Host-only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def delete_image_endpoint(
     event_id: UUID,
     image_id: UUID,

--- a/backend/app/routers/invites.py
+++ b/backend/app/routers/invites.py
@@ -6,6 +6,12 @@ from fastapi import APIRouter, Depends, status
 
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
+from app.models.errors import (
+    AUTH_RESPONSES,
+    CONFLICT_RESPONSE,
+    FORBIDDEN_RESPONSE,
+    NOT_FOUND_RESPONSE,
+)
 from app.models.invite import (
     AccessRequestDecision,
     AccessRequestListResponse,
@@ -29,7 +35,14 @@ router = APIRouter(prefix="/events/{event_id}", tags=["invites"])
 
 # --- Invites ---
 
-@router.post("/invites", status_code=status.HTTP_201_CREATED, response_model=InviteResponse)
+@router.post(
+    "/invites",
+    status_code=status.HTTP_201_CREATED,
+    response_model=InviteResponse,
+    summary="Issue an invite for a private event",
+    description="Host-only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE, **CONFLICT_RESPONSE},
+)
 def create_invite_endpoint(
     event_id: UUID,
     body: InviteCreateRequest,
@@ -39,7 +52,13 @@ def create_invite_endpoint(
     return create_invite(db, str(event_id), user_id, body)
 
 
-@router.get("/invites", response_model=InviteListResponse)
+@router.get(
+    "/invites",
+    response_model=InviteListResponse,
+    summary="List invites for an event",
+    description="Host-only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def list_invites_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),
@@ -48,7 +67,12 @@ def list_invites_endpoint(
     return list_invites(db, str(event_id), user_id)
 
 
-@router.post("/invites/{token}/accept", response_model=MessageResponse)
+@router.post(
+    "/invites/{token}/accept",
+    response_model=MessageResponse,
+    summary="Accept an invite via token",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE, **CONFLICT_RESPONSE},
+)
 def accept_invite_endpoint(
     event_id: UUID,
     token: str,
@@ -60,7 +84,13 @@ def accept_invite_endpoint(
 
 # --- Access Requests ---
 
-@router.post("/access-requests", status_code=status.HTTP_201_CREATED, response_model=AccessRequestResponse)
+@router.post(
+    "/access-requests",
+    status_code=status.HTTP_201_CREATED,
+    response_model=AccessRequestResponse,
+    summary="Request access to a private event",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE, **CONFLICT_RESPONSE},
+)
 def create_access_request_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),
@@ -69,7 +99,13 @@ def create_access_request_endpoint(
     return create_access_request(db, str(event_id), user_id)
 
 
-@router.get("/access-requests", response_model=AccessRequestListResponse)
+@router.get(
+    "/access-requests",
+    response_model=AccessRequestListResponse,
+    summary="List access requests for an event",
+    description="Host-only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def list_access_requests_endpoint(
     event_id: UUID,
     user_id: str = Depends(get_current_user_id),
@@ -78,7 +114,13 @@ def list_access_requests_endpoint(
     return list_access_requests(db, str(event_id), user_id)
 
 
-@router.patch("/access-requests/{request_id}", response_model=AccessRequestResponse)
+@router.patch(
+    "/access-requests/{request_id}",
+    response_model=AccessRequestResponse,
+    summary="Approve or deny an access request",
+    description="Host-only.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def decide_access_request_endpoint(
     event_id: UUID,
     request_id: UUID,

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Query
 
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
+from app.models.errors import AUTH_RESPONSES, NOT_FOUND_RESPONSE
 from app.models.notification import (
     NotificationListResponse,
     NotificationReadAllResponse,
@@ -22,7 +23,12 @@ from app.services.notification import (
 router = APIRouter(prefix="/notifications", tags=["notifications"])
 
 
-@router.get("/unread-count", response_model=NotificationUnreadCountResponse)
+@router.get(
+    "/unread-count",
+    response_model=NotificationUnreadCountResponse,
+    summary="Unread notification count",
+    responses={**AUTH_RESPONSES},
+)
 def unread_count_endpoint(
     user_id: str = Depends(get_current_user_id),
 ):
@@ -30,7 +36,12 @@ def unread_count_endpoint(
     return get_unread_count(db, user_id)
 
 
-@router.patch("/read-all", response_model=NotificationReadAllResponse)
+@router.patch(
+    "/read-all",
+    response_model=NotificationReadAllResponse,
+    summary="Mark all notifications as read",
+    responses={**AUTH_RESPONSES},
+)
 def read_all_notifications(
     user_id: str = Depends(get_current_user_id),
 ):
@@ -38,7 +49,12 @@ def read_all_notifications(
     return mark_all_as_read(db, user_id)
 
 
-@router.get("", response_model=NotificationListResponse)
+@router.get(
+    "",
+    response_model=NotificationListResponse,
+    summary="List notifications",
+    responses={**AUTH_RESPONSES},
+)
 def list_notifications_endpoint(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
@@ -48,7 +64,12 @@ def list_notifications_endpoint(
     return list_notifications(db, user_id, page=page, page_size=page_size)
 
 
-@router.patch("/{notification_id}/read", response_model=NotificationReadResponse)
+@router.patch(
+    "/{notification_id}/read",
+    response_model=NotificationReadResponse,
+    summary="Mark a single notification as read",
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
 def read_notification(
     notification_id: UUID,
     user_id: str = Depends(get_current_user_id),

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -8,6 +8,11 @@ from fastapi import APIRouter, Depends, Query
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id, get_optional_user_id
 from app.models.bookmark import BookmarkListResponse
+from app.models.errors import (
+    AUTH_RESPONSES,
+    FORBIDDEN_RESPONSE,
+    NOT_FOUND_RESPONSE,
+)
 from app.models.profile import HostProfileResponse, ProfileUpdateRequest
 from app.models.rating import RatingRequest, RatingResponse, ReviewListResponse
 from app.models.user import UserResponse
@@ -18,7 +23,12 @@ from app.services.rating import list_reviews, rate_host
 router = APIRouter(prefix="/users", tags=["users"])
 
 
-@router.get("/me/bookmarks", response_model=BookmarkListResponse)
+@router.get(
+    "/me/bookmarks",
+    response_model=BookmarkListResponse,
+    summary="List the authenticated user's bookmarks",
+    responses={**AUTH_RESPONSES},
+)
 def get_my_bookmarks(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
@@ -28,7 +38,12 @@ def get_my_bookmarks(
     return list_user_bookmarks(db, user_id, page=page, page_size=page_size)
 
 
-@router.put("/me", response_model=UserResponse)
+@router.put(
+    "/me",
+    response_model=UserResponse,
+    summary="Update authenticated user's profile",
+    responses={**AUTH_RESPONSES},
+)
 def update_my_profile(
     body: ProfileUpdateRequest,
     user_id: str = Depends(get_current_user_id),
@@ -37,7 +52,16 @@ def update_my_profile(
     return update_profile(db, user_id, body)
 
 
-@router.get("/{target_user_id}/profile", response_model=HostProfileResponse)
+@router.get(
+    "/{target_user_id}/profile",
+    response_model=HostProfileResponse,
+    summary="Get a user's host profile",
+    description=(
+        "Bearer token is optional. Field visibility (email / phone) is "
+        "controlled by the target user's privacy preferences."
+    ),
+    responses={**NOT_FOUND_RESPONSE},
+)
 def get_user_profile(
     target_user_id: UUID,
     current_user_id: str | None = Depends(get_optional_user_id),
@@ -46,7 +70,15 @@ def get_user_profile(
     return get_host_profile(db, str(target_user_id), current_user_id)
 
 
-@router.post("/{host_id}/ratings", response_model=RatingResponse, status_code=201)
+@router.post(
+    "/{host_id}/ratings",
+    response_model=RatingResponse,
+    status_code=201,
+    summary="Rate a host (1.0–5.0)",
+    description="Upserts a rating from the authenticated user for the given "
+                "host. Optionally includes a review text.",
+    responses={**AUTH_RESPONSES, **FORBIDDEN_RESPONSE, **NOT_FOUND_RESPONSE},
+)
 def rate_host_endpoint(
     host_id: UUID,
     body: RatingRequest,
@@ -58,7 +90,12 @@ def rate_host_endpoint(
     )
 
 
-@router.get("/{host_id}/reviews", response_model=ReviewListResponse)
+@router.get(
+    "/{host_id}/reviews",
+    response_model=ReviewListResponse,
+    summary="List reviews for a host",
+    responses={**NOT_FOUND_RESPONSE},
+)
 def list_host_reviews(
     host_id: UUID,
     page: int = Query(1, ge=1),


### PR DESCRIPTION
Enrich the FastAPI-generated OpenAPI 3.1 spec so web and mobile clients share a single, self-describing contract:

- main.py: add API description, contact, license, and tag descriptions for all 9 routers; document auth, error envelope, pagination, and rate-limiting conventions in the top-level description.
- models/errors.py (new): standard ErrorResponse / ValidationErrorResponse schemas plus reusable response dicts (AUTH/FORBIDDEN/NOT_FOUND/CONFLICT/ RATE_LIMIT) so each endpoint advertises the error shapes it returns.
- routers/*: add summary, description, and responses metadata to every endpoint across auth, events, comments, notifications, bookmarks, attendances, categories, invites, and users.

No behavioural changes — only OpenAPI metadata.

Closes #249 