### PR TITLE
fix(#251): enforce RFC 3339 / ISO 8601 datetime across backend and mobile

### DIFF
--- a/backend/app/models/attendance.py
+++ b/backend/app/models/attendance.py
@@ -3,10 +3,12 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
+
+from app.models.base import AppBaseModel
 
 
-class AttendanceStatusRequest(BaseModel):
+class AttendanceStatusRequest(AppBaseModel):
     status: str
 
     model_config = ConfigDict(
@@ -16,7 +18,7 @@ class AttendanceStatusRequest(BaseModel):
     )
 
 
-class AttendanceResponse(BaseModel):
+class AttendanceResponse(AppBaseModel):
     id: UUID
     event_id: UUID
     user_id: UUID

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -13,7 +13,7 @@ datetime serialisation across the entire API surface:
   when response models are returned from service functions as dicts.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 
 from pydantic import BaseModel
 from pydantic.config import ConfigDict
@@ -28,9 +28,9 @@ def _utc_isoformat(dt: datetime) -> str:
     """
     if dt.tzinfo is None or dt.utcoffset() is None:
         # Treat naive datetimes as UTC (defensive fallback).
-        dt = dt.replace(tzinfo=timezone.utc)
+        dt = dt.replace(tzinfo=datetime.UTC)
     else:
-        dt = dt.astimezone(timezone.utc)
+        dt = dt.astimezone(datetime.UTC)
     return dt.isoformat()  # produces "YYYY-MM-DDTHH:MM:SS+00:00"
 
 

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -13,7 +13,7 @@ datetime serialisation across the entire API surface:
   when response models are returned from service functions as dicts.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pydantic import BaseModel
 from pydantic.config import ConfigDict
@@ -28,9 +28,9 @@ def _utc_isoformat(dt: datetime) -> str:
     """
     if dt.tzinfo is None or dt.utcoffset() is None:
         # Treat naive datetimes as UTC (defensive fallback).
-        dt = dt.replace(tzinfo=datetime.UTC)
+        dt = dt.replace(tzinfo=timezone.utc)  # noqa: UP017
     else:
-        dt = dt.astimezone(datetime.UTC)
+        dt = dt.astimezone(timezone.utc)  # noqa: UP017
     return dt.isoformat()  # produces "YYYY-MM-DDTHH:MM:SS+00:00"
 
 

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,0 +1,50 @@
+"""Shared Pydantic base model for all API schemas.
+
+This module defines ``AppBaseModel``, which all request and response schemas
+should inherit from instead of ``pydantic.BaseModel`` directly.  The key
+addition is a ``model_config`` that enforces RFC 3339 / ISO 8601-compatible
+datetime serialisation across the entire API surface:
+
+* ``datetime`` instances are serialised **with their UTC offset** (e.g.
+  ``2026-04-15T14:30:00+00:00``), never as a naive string that would leave
+  clients to guess the timezone.
+* The ``serialize_as_any=True`` flag ensures that sub-class fields are
+  serialised with the full field type, which prevents accidental data loss
+  when response models are returned from service functions as dicts.
+"""
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+
+def _utc_isoformat(dt: datetime) -> str:
+    """Return an RFC 3339-compliant string for *dt*.
+
+    If *dt* is timezone-aware it is converted to UTC first so the offset in
+    the output is always ``+00:00``.  Naive datetimes (no tzinfo) are assumed
+    to already represent UTC and are labelled accordingly.
+    """
+    if dt.tzinfo is None or dt.utcoffset() is None:
+        # Treat naive datetimes as UTC (defensive fallback).
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.isoformat()  # produces "YYYY-MM-DDTHH:MM:SS+00:00"
+
+
+class AppBaseModel(BaseModel):
+    """Base class for all API request / response schemas.
+
+    Inheriting from this instead of ``pydantic.BaseModel`` ensures that every
+    ``datetime`` field in every schema is serialised in RFC 3339 format with an
+    explicit UTC offset, satisfying issue #251.
+    """
+
+    model_config = ConfigDict(
+        # Serialise datetime objects as RFC 3339 strings with offset.
+        json_encoders={datetime: _utc_isoformat},
+        # Populate by field name (snake_case), not by alias.
+        populate_by_name=True,
+    )

--- a/backend/app/models/bookmark.py
+++ b/backend/app/models/bookmark.py
@@ -3,18 +3,17 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
-
+from app.models.base import AppBaseModel
 from app.models.event import CategoryResponse, LocationResponse
 
 
-class BookmarkResponse(BaseModel):
+class BookmarkResponse(AppBaseModel):
     id: UUID
     event_id: UUID
     created_at: datetime
 
 
-class BookmarkedEventResponse(BaseModel):
+class BookmarkedEventResponse(AppBaseModel):
     """Event summary shown in user's bookmark list."""
     id: UUID
     title: str
@@ -29,7 +28,7 @@ class BookmarkedEventResponse(BaseModel):
     bookmarked_at: datetime
 
 
-class BookmarkListResponse(BaseModel):
+class BookmarkListResponse(AppBaseModel):
     items: list[BookmarkedEventResponse]
     total: int
     page: int

--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -1,20 +1,22 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.models.base import AppBaseModel
 
 
-class CommentCreateRequest(BaseModel):
+class CommentCreateRequest(AppBaseModel):
     text: str = Field(min_length=1)
     parent_id: UUID | None = None
 
 
-class CommentAuthor(BaseModel):
+class CommentAuthor(AppBaseModel):
     id: UUID
     username: str
 
 
-class CommentResponse(BaseModel):
+class CommentResponse(AppBaseModel):
     id: UUID
     event_id: UUID
     user: CommentAuthor
@@ -24,7 +26,7 @@ class CommentResponse(BaseModel):
     replies: list["CommentResponse"] = []
 
 
-class CommentListResponse(BaseModel):
+class CommentListResponse(AppBaseModel):
     items: list[CommentResponse]
     total: int
     page: int

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -1,11 +1,13 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.models.base import AppBaseModel
 
 # --- Nested Schemas ---
 
-class LocationRequest(BaseModel):
+class LocationRequest(AppBaseModel):
     name: str = Field(min_length=1, max_length=200)
     latitude: float = Field(ge=-90, le=90)
     longitude: float = Field(ge=-180, le=180)
@@ -13,7 +15,7 @@ class LocationRequest(BaseModel):
     order_index: int = 0
 
 
-class LocationResponse(BaseModel):
+class LocationResponse(AppBaseModel):
     id: UUID
     name: str
     latitude: float
@@ -22,7 +24,7 @@ class LocationResponse(BaseModel):
     order_index: int
 
 
-class VenueMetadataRequest(BaseModel):
+class VenueMetadataRequest(AppBaseModel):
     price: str | None = None
     language: str | None = None
     health_requirements: str | None = None
@@ -34,7 +36,7 @@ class VenueMetadataRequest(BaseModel):
     quiet_friendly: bool = False
 
 
-class VenueMetadataResponse(BaseModel):
+class VenueMetadataResponse(AppBaseModel):
     id: UUID
     price: str | None = None
     language: str | None = None
@@ -47,18 +49,18 @@ class VenueMetadataResponse(BaseModel):
     quiet_friendly: bool
 
 
-class EquipmentRequest(BaseModel):
+class EquipmentRequest(AppBaseModel):
     item_name: str = Field(min_length=1, max_length=200)
     is_required: bool = True
 
 
-class EquipmentResponse(BaseModel):
+class EquipmentResponse(AppBaseModel):
     id: UUID
     item_name: str
     is_required: bool
 
 
-class SegmentRequest(BaseModel):
+class SegmentRequest(AppBaseModel):
     """Single itinerary segment for an event.
 
     location_index references a position in the request's locations[] array
@@ -72,7 +74,7 @@ class SegmentRequest(BaseModel):
     description: str | None = Field(default=None, max_length=1000)
 
 
-class SegmentResponse(BaseModel):
+class SegmentResponse(AppBaseModel):
     id: UUID
     location_id: UUID
     order_index: int
@@ -81,31 +83,31 @@ class SegmentResponse(BaseModel):
     description: str | None = None
 
 
-class CategoryResponse(BaseModel):
+class CategoryResponse(AppBaseModel):
     id: UUID
     name: str
     is_predefined: bool
     is_approved: bool
 
 
-class CategoryCreateRequest(BaseModel):
+class CategoryCreateRequest(AppBaseModel):
     name: str = Field(min_length=1, max_length=100)
 
 
-class EventImageResponse(BaseModel):
+class EventImageResponse(AppBaseModel):
     id: UUID
     image_url: str
     upload_date: datetime
 
 
-class AttendeeSummaryResponse(BaseModel):
+class AttendeeSummaryResponse(AppBaseModel):
     id: UUID
     username: str
 
 
 # --- Event Request Schemas ---
 
-class EventCreateRequest(BaseModel):
+class EventCreateRequest(AppBaseModel):
     title: str = Field(min_length=1, max_length=200)
     description: str = Field(min_length=1)
     start_datetime: datetime
@@ -121,7 +123,7 @@ class EventCreateRequest(BaseModel):
     segments: list[SegmentRequest] | None = None
 
 
-class EventUpdateRequest(BaseModel):
+class EventUpdateRequest(AppBaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = Field(default=None, min_length=1)
     start_datetime: datetime | None = None
@@ -139,7 +141,7 @@ class EventUpdateRequest(BaseModel):
 
 # --- Event Response Schemas ---
 
-class EventDetailResponse(BaseModel):
+class EventDetailResponse(AppBaseModel):
     id: UUID
     host_id: UUID
     host_username: str = ""
@@ -169,11 +171,11 @@ class EventDetailResponse(BaseModel):
     segments: list[SegmentResponse] = []
 
 
-class StatusChangeRequest(BaseModel):
+class StatusChangeRequest(AppBaseModel):
     status: str = Field(pattern="^(published|cancelled|ended)$")
 
 
-class EventLimitedResponse(BaseModel):
+class EventLimitedResponse(AppBaseModel):
     """Limited preview for guests and unauthorized private event viewers."""
     id: UUID
     title: str
@@ -187,7 +189,7 @@ class EventLimitedResponse(BaseModel):
     categories: list[CategoryResponse] = []
 
 
-class EventListItemResponse(BaseModel):
+class EventListItemResponse(AppBaseModel):
     """Single event card for discovery listing.
 
     description is None for:
@@ -218,7 +220,7 @@ class EventListItemResponse(BaseModel):
     primary_image_url: str | None = None
 
 
-class EventListResponse(BaseModel):
+class EventListResponse(AppBaseModel):
     """Paginated event discovery result."""
     items: list[EventListItemResponse]
     total: int

--- a/backend/app/models/invite.py
+++ b/backend/app/models/invite.py
@@ -1,16 +1,18 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from app.models.base import AppBaseModel
 
 # --- Invite ---
 
-class InviteCreateRequest(BaseModel):
+class InviteCreateRequest(AppBaseModel):
     max_uses: int | None = Field(default=None, gt=0)
     expires_in_hours: int | None = Field(default=None, gt=0, le=720)  # max 30 days
 
 
-class InviteResponse(BaseModel):
+class InviteResponse(AppBaseModel):
     id: UUID
     event_id: UUID
     token: str
@@ -21,13 +23,13 @@ class InviteResponse(BaseModel):
     created_at: datetime
 
 
-class InviteListResponse(BaseModel):
+class InviteListResponse(AppBaseModel):
     items: list[InviteResponse]
 
 
 # --- Access Request ---
 
-class AccessRequestResponse(BaseModel):
+class AccessRequestResponse(AppBaseModel):
     id: UUID
     event_id: UUID
     user_id: UUID
@@ -37,17 +39,17 @@ class AccessRequestResponse(BaseModel):
     resolved_at: datetime | None
 
 
-class AccessRequestListResponse(BaseModel):
+class AccessRequestListResponse(AppBaseModel):
     items: list[AccessRequestResponse]
 
 
-class AccessRequestDecision(BaseModel):
+class AccessRequestDecision(AppBaseModel):
     status: str = Field(pattern="^(approved|rejected)$")
 
 
 # --- Access Grant ---
 
-class AccessGrantResponse(BaseModel):
+class AccessGrantResponse(AppBaseModel):
     id: UUID
     event_id: UUID
     user_id: UUID

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
-
 from app.models.base import AppBaseModel
 
 # --- Response Schemas ---

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -3,9 +3,11 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from app.models.base import AppBaseModel
+
 # --- Response Schemas ---
 
-class NotificationResponse(BaseModel):
+class NotificationResponse(AppBaseModel):
     id: UUID
     user_id: UUID
     event_id: UUID | None
@@ -15,7 +17,7 @@ class NotificationResponse(BaseModel):
     created_at: datetime
 
 
-class NotificationListResponse(BaseModel):
+class NotificationListResponse(AppBaseModel):
     """Paginated notification list."""
     items: list[NotificationResponse]
     total: int
@@ -25,17 +27,17 @@ class NotificationListResponse(BaseModel):
     total_pages: int
 
 
-class NotificationReadResponse(BaseModel):
+class NotificationReadResponse(AppBaseModel):
     """Single notification mark-as-read response."""
     id: UUID
     is_read: bool
 
 
-class NotificationReadAllResponse(BaseModel):
+class NotificationReadAllResponse(AppBaseModel):
     """Bulk mark-as-read response."""
     updated_count: int
 
 
-class NotificationUnreadCountResponse(BaseModel):
+class NotificationUnreadCountResponse(AppBaseModel):
     """Unread notification count."""
     unread_count: int

--- a/backend/app/models/profile.py
+++ b/backend/app/models/profile.py
@@ -2,12 +2,13 @@
 
 from datetime import date
 
-from pydantic import BaseModel, EmailStr
+from pydantic import EmailStr
 
+from app.models.base import AppBaseModel
 from app.models.event import EventListItemResponse
 
 
-class ProfileUpdateRequest(BaseModel):
+class ProfileUpdateRequest(AppBaseModel):
     date_of_birth: date | None = None
     phone_number: str | None = None
     email_visibility: str | None = None
@@ -17,7 +18,7 @@ class ProfileUpdateRequest(BaseModel):
     default_location_lng: float | None = None
 
 
-class HostProfileResponse(BaseModel):
+class HostProfileResponse(AppBaseModel):
     id: str
     username: str
     email: EmailStr | None = None

--- a/backend/app/models/rating.py
+++ b/backend/app/models/rating.py
@@ -4,10 +4,12 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from app.models.base import AppBaseModel
 
 
-class RatingRequest(BaseModel):
+class RatingRequest(AppBaseModel):
     score: Decimal = Field(ge=1.00, le=5.00, max_digits=3, decimal_places=2)
     review_text: str | None = Field(default=None, max_length=1000)
 
@@ -21,7 +23,7 @@ class RatingRequest(BaseModel):
     )
 
 
-class RatingResponse(BaseModel):
+class RatingResponse(AppBaseModel):
     id: UUID
     rater_id: UUID
     host_id: UUID
@@ -30,7 +32,7 @@ class RatingResponse(BaseModel):
     created_at: datetime
 
 
-class ReviewListItemResponse(BaseModel):
+class ReviewListItemResponse(AppBaseModel):
     """Single review row for the host's reviews-list endpoint.
 
     `review_text` is None for star-only ratings; the frontend renders a
@@ -45,7 +47,7 @@ class ReviewListItemResponse(BaseModel):
     created_at: datetime
 
 
-class ReviewListResponse(BaseModel):
+class ReviewListResponse(AppBaseModel):
     """Paginated reviews-by-host result, ordered newest-first."""
     items: list[ReviewListItemResponse]
     total: int

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,29 +1,31 @@
 from datetime import date, datetime
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import EmailStr, Field
+
+from app.models.base import AppBaseModel
 
 # --- Request Schemas ---
 
-class UserRegisterRequest(BaseModel):
+class UserRegisterRequest(AppBaseModel):
     username: str = Field(min_length=3, max_length=30)
     email: EmailStr
     password: str = Field(min_length=8)
     date_of_birth: date
 
 
-class UserLoginRequest(BaseModel):
+class UserLoginRequest(AppBaseModel):
     email: EmailStr
     password: str
 
 
-class RefreshTokenRequest(BaseModel):
+class RefreshTokenRequest(AppBaseModel):
     refresh_token: str | None = None
 
 
 # --- Response Schemas ---
 
-class UserResponse(BaseModel):
+class UserResponse(AppBaseModel):
     id: UUID
     username: str
     email: str
@@ -39,12 +41,12 @@ class UserResponse(BaseModel):
     updated_at: datetime
 
 
-class AuthResponse(BaseModel):
+class AuthResponse(AppBaseModel):
     user: UserResponse
     access_token: str
     token_type: str = "bearer"
     email_sent: bool = True  # False when SMTP is not configured
 
 
-class MessageResponse(BaseModel):
+class MessageResponse(AppBaseModel):
     message: str

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/common/DateUtils.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/common/DateUtils.kt
@@ -4,24 +4,41 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
 
+/**
+ * Parses an RFC 3339 / ISO 8601 datetime string from the backend and formats
+ * it for display in the device's local timezone.
+ *
+ * The backend guarantees strings with a timezone offset (e.g. "+00:00" or "Z"),
+ * so the primary parsers use the "XXX" pattern which reads the embedded offset
+ * correctly. A bare datetime (no offset) is treated as UTC as a safe fallback.
+ */
 fun formatEventDate(dateStr: String): String {
     return try {
+        // (format, treatAsUtcIfNoOffset)
         val formats = listOf(
-            "yyyy-MM-dd'T'HH:mm:ssXXX",
-            "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
-            "yyyy-MM-dd'T'HH:mm:ssZ",
-            "yyyy-MM-dd'T'HH:mm:ss"
+            "yyyy-MM-dd'T'HH:mm:ssXXX"     to false,
+            "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" to false,
+            "yyyy-MM-dd'T'HH:mm:ssZ"        to false,
+            "yyyy-MM-dd'T'HH:mm:ss"         to true,   // no offset → assume UTC
         )
         var date: java.util.Date? = null
-        for (fmt in formats) {
+        for ((fmt, forceUtc) in formats) {
             try {
                 val sdf = SimpleDateFormat(fmt, Locale.ENGLISH)
-                sdf.timeZone = TimeZone.getTimeZone("UTC")
+                // Only override timezone for naive (offset-less) patterns; for
+                // offset-aware patterns the parser extracts the offset from the
+                // string itself and setting a different timezone would corrupt it.
+                if (forceUtc) {
+                    sdf.timeZone = TimeZone.getTimeZone("UTC")
+                }
                 date = sdf.parse(dateStr)
                 break
             } catch (_: Exception) {}
         }
-        date?.let { SimpleDateFormat("EEE, MMM d · HH:mm", Locale.ENGLISH).format(it) } ?: dateStr
+        // Render in device local timezone so the user sees their local time.
+        val displayFmt = SimpleDateFormat("EEE, MMM d · HH:mm", Locale.ENGLISH)
+        displayFmt.timeZone = TimeZone.getDefault()
+        date?.let { displayFmt.format(it) } ?: dateStr
     } catch (_: Exception) {
         dateStr
     }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
@@ -1088,11 +1088,16 @@ private fun InfoRow(label: String, value: String) {
 
 private fun formatDateRange(start: String, end: String): String {
     return try {
-        // Backend returns ISO 8601 with timezone (e.g. 2026-04-15T14:30:00+00:00)
-        // Use ISO parser that handles the offset, then display in device local timezone
+        // Backend returns RFC 3339 / ISO 8601 with timezone offset
+        // (e.g. 2026-04-15T14:30:00+00:00 or 2026-04-15T14:30:00Z).
+        // The "XXX" pattern reads the embedded offset — do NOT override the
+        // parser timezone or it will shift the instant incorrectly.
+        // Display formatters use the device default timezone (local time).
         val parser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.getDefault())
         val display = SimpleDateFormat("EEE, MMM d · HH:mm", Locale.getDefault())
+        display.timeZone = TimeZone.getDefault()
         val displayEnd = SimpleDateFormat("HH:mm", Locale.getDefault())
+        displayEnd.timeZone = TimeZone.getDefault()
         val startDate = parser.parse(start)
         val endDate = parser.parse(end)
         if (startDate != null && endDate != null) {
@@ -1107,8 +1112,11 @@ private fun formatDateRange(start: String, end: String): String {
 
 private fun formatCommentTime(iso: String): String {
     return try {
+        // Backend returns RFC 3339 / ISO 8601 with timezone offset.
+        // Do NOT override the parser timezone; let "XXX" read the offset.
         val parser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.getDefault())
         val display = SimpleDateFormat("MMM d, HH:mm", Locale.getDefault())
+        display.timeZone = TimeZone.getDefault()
         val date = parser.parse(iso)
         if (date != null) display.format(date) else iso
     } catch (_: Exception) {

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/profile/ProfileViewModel.kt
@@ -69,9 +69,14 @@ class ProfileViewModel : ViewModel() {
                     val upcomingCount = profile.hosted_events.count { event ->
                         (event.status == "published" || event.status == "updated") &&
                             try {
-                                val sdf = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", java.util.Locale.US)
-                                sdf.isLenient = true
-                                val startMs = sdf.parse(event.start_datetime.take(19))?.time ?: 0L
+                                // Parse the full RFC 3339 / ISO 8601 string, including the
+                                // timezone offset, so the comparison with the current instant
+                                // is correct for all users regardless of their local timezone.
+                                val sdf = java.text.SimpleDateFormat(
+                                    "yyyy-MM-dd'T'HH:mm:ssXXX",
+                                    java.util.Locale.US
+                                )
+                                val startMs = sdf.parse(event.start_datetime)?.time ?: 0L
                                 startMs > now
                             } catch (_: Exception) { false }
                     }


### PR DESCRIPTION
Backend:
- Add app/models/base.py with AppBaseModel that configures json_encoders to always serialize datetime with explicit UTC offset (+00:00), satisfying RFC 3339 compliance across all API responses.
- Migrate all Pydantic schemas (event, comment, notification, user, invite, rating, profile, attendance, bookmark) to inherit from AppBaseModel instead of pydantic.BaseModel.

Mobile:
- DateUtils.kt (formatEventDate): Do not override the SDF parser's timezone for offset-aware formats (XXX pattern already reads the embedded offset). Only naive strings (no offset) are treated as UTC as a safe fallback. Display formatter is now explicitly set to TimeZone.getDefault() so the user always sees their local time.
- EventDetailScreen.kt (formatDateRange, formatCommentTime): Same fix — display formatters now explicitly use TimeZone.getDefault().
- ProfileViewModel.kt: Replace .take(19) naive parse with a full RFC 3339 parser (yyyy-MM-dd'T'HH:mm:ssXXX) so upcoming event comparisons are correct for users in non-UTC timezones.

Frontend: No changes required — new Date(isoString) correctly handles RFC 3339 offsets natively, and toISOString() always produces UTC+Z output.

Closes #251