### PR TITLE
feat: multilocation-itenary-mobile

### DIFF
--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
@@ -254,6 +254,14 @@ data class LocationRequest(
     val order_index: Int = 0
 )
 
+data class SegmentRequest(
+    val location_index: Int,
+    val order_index: Int,
+    val start_datetime: String,
+    val end_datetime: String,
+    val description: String? = null
+)
+
 data class VenueMetadataRequest(
     val health_requirements: String? = null,
     val wheelchair_access: Boolean = false,
@@ -275,6 +283,7 @@ data class EventCreateRequest(
     val status: String = "draft",      // "draft" | "published"
     val category_ids: List<String>,
     val locations: List<LocationRequest>,
+    val segments: List<SegmentRequest>? = null,
     val venue_metadata: VenueMetadataRequest? = null
 )
 
@@ -289,6 +298,7 @@ data class EventUpdateRequest(
     val clear_attendee_limit: Boolean = false,
     val category_ids: List<String>? = null,
     val locations: List<LocationRequest>? = null,
+    val segments: List<SegmentRequest>? = null,
     val venue_metadata: VenueMetadataRequest? = null
 )
 

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/EventDetailDto.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/EventDetailDto.kt
@@ -4,6 +4,15 @@ package com.bounswe.group9.mobile.data.remote
  * Full detail response from GET /events/{event_id} for authenticated users
  * viewing public events (or host/granted users viewing private events).
  */
+data class SegmentDto(
+    val id: String,
+    val location_id: String,
+    val order_index: Int,
+    val start_datetime: String,
+    val end_datetime: String,
+    val description: String? = null
+)
+
 data class EventDetailDto(
     val id: String,
     val host_id: String,
@@ -28,7 +37,8 @@ data class EventDetailDto(
     val categories: List<CategoryDto>,
     val images: List<EventImageDto>,
     val venue_metadata: VenueMetadataDto?,
-    val equipment_requirements: List<EquipmentDto>
+    val equipment_requirements: List<EquipmentDto>,
+    val segments: List<SegmentDto>? = null
 )
 
 data class EventImageDto(

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Reorder
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -45,18 +46,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import coil.compose.AsyncImage
 import java.util.Date
 import java.util.Locale
@@ -939,8 +946,51 @@ private fun LocationStep(uiState: CreateEventUiState, viewModel: CreateEventView
             )
             Spacer(Modifier.height(12.dp))
 
+            // Drag-and-drop reorder state (issue #160 AC #1).
+            // - draggedIndex: which row is being dragged, null when idle.
+            // - dragOffsetY: cumulative vertical drag distance (px) for that row.
+            // - itemHeights: per-index measured height so we can convert
+            //   dragOffsetY into a target index regardless of card expansion
+            //   (segment-fields expand changes per-row height significantly).
+            var draggedIndex by remember { mutableStateOf<Int?>(null) }
+            var dragOffsetY by remember { mutableStateOf(0f) }
+            val itemHeights = remember { mutableStateMapOf<Int, Int>() }
+
+            // Convert the live dragOffsetY into the would-be target index.
+            // We sum heights of items below (when dragging down) or above
+            // (when dragging up) and "cross" into the next row once we've
+            // moved past half its height — feels natural and matches
+            // ItemTouchHelper's default behaviour.
+            fun computeTarget(from: Int, offsetY: Float): Int {
+                if (offsetY > 0f) {
+                    var acc = 0
+                    var idx = from + 1
+                    var target = from
+                    while (idx < uiState.locations.size) {
+                        val h = itemHeights[idx] ?: 0
+                        acc += h
+                        if (offsetY > acc - h / 2f) target = idx
+                        idx++
+                    }
+                    return target
+                } else if (offsetY < 0f) {
+                    var acc = 0
+                    var idx = from - 1
+                    var target = from
+                    while (idx >= 0) {
+                        val h = itemHeights[idx] ?: 0
+                        acc += h
+                        if (-offsetY > acc - h / 2f) target = idx
+                        idx--
+                    }
+                    return target
+                }
+                return from
+            }
+
             uiState.locations.forEachIndexed { index, loc ->
                 val canReorder = uiState.locations.size > 1 && !readOnly
+                val isDragging = draggedIndex == index
                 LocationEntryCard(
                     index = index,
                     entry = loc,
@@ -948,6 +998,28 @@ private fun LocationStep(uiState: CreateEventUiState, viewModel: CreateEventView
                     canDelete = uiState.locations.size > 1 && !readOnly,
                     canMoveUp = canReorder && index > 0,
                     canMoveDown = canReorder && index < uiState.locations.size - 1,
+                    canReorder = canReorder,
+                    isDragging = isDragging,
+                    dragOffsetY = if (isDragging) dragOffsetY else 0f,
+                    onSizeMeasured = { px -> itemHeights[index] = px },
+                    onDragStart = {
+                        draggedIndex = index
+                        dragOffsetY = 0f
+                    },
+                    onDrag = { dy -> dragOffsetY += dy },
+                    onDragEnd = {
+                        val from = draggedIndex
+                        val target = if (from != null) computeTarget(from, dragOffsetY) else null
+                        if (from != null && target != null && target != from) {
+                            viewModel.moveLocation(from, target)
+                        }
+                        draggedIndex = null
+                        dragOffsetY = 0f
+                    },
+                    onDragCancel = {
+                        draggedIndex = null
+                        dragOffsetY = 0f
+                    },
                     readOnly = readOnly,
                     onNameChange = { viewModel.onLocationNameChange(index, it) },
                     onSetOnMap = { if (!readOnly) pickingLocationIndex = index },
@@ -992,6 +1064,14 @@ private fun LocationEntryCard(
     canDelete: Boolean,
     canMoveUp: Boolean,
     canMoveDown: Boolean,
+    canReorder: Boolean,
+    isDragging: Boolean,
+    dragOffsetY: Float,
+    onSizeMeasured: (Int) -> Unit,
+    onDragStart: () -> Unit,
+    onDrag: (Float) -> Unit,
+    onDragEnd: () -> Unit,
+    onDragCancel: () -> Unit,
     readOnly: Boolean,
     onNameChange: (String) -> Unit,
     onSetOnMap: () -> Unit,
@@ -1002,7 +1082,22 @@ private fun LocationEntryCard(
     onShowPicker: (String) -> Unit,
     onSegmentDescriptionChange: (String) -> Unit
 ) {
-    Column {
+    // While dragging:
+    //  - lift the card visually (shadow + raised z so it draws above siblings)
+    //  - translate it by dragOffsetY so the user sees it follow their finger
+    //  - other rows stay put; the actual list reorder happens once on
+    //    drag end (computeTarget in LocationStep) — this is the same UX
+    //    pattern as Android's ItemTouchHelper-based drag-to-reorder.
+    Column(
+        modifier = Modifier
+            .onSizeChanged { onSizeMeasured(it.height) }
+            .zIndex(if (isDragging) 1f else 0f)
+            .offset { IntOffset(0, dragOffsetY.toInt()) }
+            .then(
+                if (isDragging) Modifier.shadow(elevation = 8.dp, shape = MaterialTheme.shapes.medium)
+                else Modifier
+            )
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Surface(
                 shape = CircleShape,
@@ -1025,9 +1120,35 @@ private fun LocationEntryCard(
                 fontSize = 14.sp,
                 modifier = Modifier.weight(1f)
             )
-            // Reorder controls — moving a stop instantly re-numbers every card
-            // (issue #160 AC #1). The badge above reads `index + 1`, so reordering
-            // the underlying list updates the displayed numbers in one frame.
+            // Drag handle — long-press + drag to reorder. The icon-only
+            // hit area starts the gesture; once the user has held it for
+            // ~500 ms the card lifts and follows their finger. Releasing
+            // commits the new position. This is the primary reorder
+            // affordance (issue #160 AC #1: drag-and-drop).
+            if (canReorder) {
+                Icon(
+                    Icons.Default.Reorder,
+                    contentDescription = "Drag to reorder stop",
+                    modifier = Modifier
+                        .size(32.dp)
+                        .padding(6.dp)
+                        .pointerInput(index) {
+                            detectDragGesturesAfterLongPress(
+                                onDragStart = { onDragStart() },
+                                onDragEnd = { onDragEnd() },
+                                onDragCancel = { onDragCancel() },
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    onDrag(dragAmount.y)
+                                },
+                            )
+                        },
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            // ↑ / ↓ accessibility fallback — gives keyboard / screen-reader
+            // users (and anyone who can't comfortably long-press) the same
+            // reorder capability the drag handle exposes.
             if (canMoveUp || canMoveDown) {
                 IconButton(
                     onClick = onMoveUp,

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
@@ -26,12 +26,17 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
@@ -57,6 +62,7 @@ import java.util.Date
 import java.util.Locale
 import com.bounswe.group9.mobile.data.remote.EventDetailDto
 import com.bounswe.group9.mobile.ui.discovery.LocationPickerMapView
+import com.bounswe.group9.mobile.ui.discovery.MultiLocationMapView
 import com.bounswe.group9.mobile.ui.theme.BrandDark
 import com.bounswe.group9.mobile.ui.theme.BrandMid
 import com.bounswe.group9.mobile.ui.theme.BrandSurfaceLight
@@ -791,108 +797,378 @@ private fun ScheduleStep(uiState: CreateEventUiState, viewModel: CreateEventView
 
 // ── Step 2: Location ──────────────────────────────────────────────────────────
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LocationStep(uiState: CreateEventUiState, viewModel: CreateEventViewModel) {
     val readOnly = uiState.eventAlreadyStarted
-    val selectedLat = uiState.locationLat.toDoubleOrNull()
-    val selectedLng = uiState.locationLng.toDoubleOrNull()
+    var pickingLocationIndex by remember { mutableStateOf(-1) }
+    val dateFmt: java.text.SimpleDateFormat = remember { java.text.SimpleDateFormat("yyyy-MM-dd", Locale.US) }
+    fun parseMs(d: String): Long? = try { dateFmt.parse(d)?.time } catch (_: Exception) { null }
+    fun parseHour(t: String) = t.split(":").getOrNull(0)?.toIntOrNull() ?: 9
+    fun parseMin(t: String) = t.split(":").getOrNull(1)?.toIntOrNull() ?: 0
 
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        if (uiState.eventAlreadyStarted) {
-            FeedbackBanner(
-                "This event has already started — location cannot be changed.",
-                FeedbackTone.Error
-            )
-        }
+    // Tracks which (locationIndex, field) picker to show: field = startDate|startTime|endDate|endTime
+    var showPickerFor by remember { mutableStateOf<Pair<Int, String>?>(null) }
 
-        // Place name field
-        StepCard {
-            FieldLabel("Place name", helper = "Give your venue a recognisable name.")
-            Spacer(Modifier.height(8.dp))
-            OutlinedTextField(
-                value = uiState.locationName,
-                onValueChange = { if (!readOnly) viewModel.onLocationNameChange(it) },
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text("Place name") },
-                placeholder = { Text("e.g. Grand Arena, Istanbul") },
-                singleLine = true,
-                enabled = !readOnly,
-                isError = uiState.locationError != null
-            )
-            uiState.locationError?.let {
-                Spacer(Modifier.height(4.dp))
-                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
-            }
-        }
-
-        // Map picker card
-        StepCard {
-            FieldLabel(
-                "Pin on map",
-                helper = if (readOnly) "Location is locked for started events."
-                         else "Tap anywhere on the map to set the venue coordinates."
-            )
-            Spacer(Modifier.height(10.dp))
-
-            // The map — fixed height so it sits inside the scroll layout nicely
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(320.dp)
-                    .clip(RoundedCornerShape(12.dp))
-            ) {
-                LocationPickerMapView(
-                    selectedLat = selectedLat,
-                    selectedLng = selectedLng,
-                    onLocationPicked = { lat, lng ->
-                        if (!readOnly) viewModel.onLocationPicked(lat, lng)
+    showPickerFor?.let { (idx, field) ->
+        val loc = uiState.locations.getOrNull(idx) ?: return@let
+        when (field) {
+            "startDate" -> {
+                val state = rememberDatePickerState(initialSelectedDateMillis = parseMs(loc.segmentStartDate))
+                DatePickerDialog(
+                    onDismissRequest = { showPickerFor = null },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            state.selectedDateMillis?.let { viewModel.onSegmentStartDateChange(idx, dateFmt.format(Date(it))) }
+                            showPickerFor = null
+                        }) { Text("OK") }
                     },
-                    modifier = Modifier.fillMaxSize()
-                )
-
-                // Lock overlay when readOnly
-                if (readOnly) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(Color.Black.copy(alpha = 0.35f)),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Surface(
-                            shape = RoundedCornerShape(20.dp),
-                            color = Color.Black.copy(alpha = 0.6f)
-                        ) {
-                            Text(
-                                "🔒 Location locked",
-                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                                color = Color.White,
-                                fontWeight = FontWeight.SemiBold
-                            )
-                        }
-                    }
-                }
+                    dismissButton = { TextButton(onClick = { showPickerFor = null }) { Text("Cancel") } }
+                ) { DatePicker(state = state) }
             }
+            "startTime" -> {
+                val state = rememberTimePickerState(initialHour = parseHour(loc.segmentStartTime), initialMinute = parseMin(loc.segmentStartTime))
+                AlertDialog(
+                    onDismissRequest = { showPickerFor = null },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.onSegmentStartTimeChange(idx, String.format("%02d:%02d", state.hour, state.minute))
+                            showPickerFor = null
+                        }) { Text("OK") }
+                    },
+                    dismissButton = { TextButton(onClick = { showPickerFor = null }) { Text("Cancel") } },
+                    text = { TimePicker(state = state) }
+                )
+            }
+            "endDate" -> {
+                val state = rememberDatePickerState(initialSelectedDateMillis = parseMs(loc.segmentEndDate))
+                DatePickerDialog(
+                    onDismissRequest = { showPickerFor = null },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            state.selectedDateMillis?.let { viewModel.onSegmentEndDateChange(idx, dateFmt.format(Date(it))) }
+                            showPickerFor = null
+                        }) { Text("OK") }
+                    },
+                    dismissButton = { TextButton(onClick = { showPickerFor = null }) { Text("Cancel") } }
+                ) { DatePicker(state = state) }
+            }
+            "endTime" -> {
+                val state = rememberTimePickerState(initialHour = parseHour(loc.segmentEndTime), initialMinute = parseMin(loc.segmentEndTime))
+                AlertDialog(
+                    onDismissRequest = { showPickerFor = null },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.onSegmentEndTimeChange(idx, String.format("%02d:%02d", state.hour, state.minute))
+                            showPickerFor = null
+                        }) { Text("OK") }
+                    },
+                    dismissButton = { TextButton(onClick = { showPickerFor = null }) { Text("Cancel") } },
+                    text = { TimePicker(state = state) }
+                )
+            }
+        }
+    }
 
-            // Coordinate summary row
-            if (selectedLat != null && selectedLng != null) {
-                Spacer(Modifier.height(10.dp))
-                Surface(shape = RoundedCornerShape(8.dp), color = Color(0xFFF0EDE9)) {
-                    Text(
-                        "📍 ${uiState.locationName.ifBlank { "Location" }} — ${"%.5f".format(selectedLat)}, ${"%.5f".format(selectedLng)}",
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = BrandDark,
-                        fontWeight = FontWeight.Medium
+    // Map picker bottom sheet
+    if (pickingLocationIndex >= 0) {
+        val pickedIdx = pickingLocationIndex
+        val loc = uiState.locations.getOrNull(pickedIdx)
+        ModalBottomSheet(onDismissRequest = { pickingLocationIndex = -1 }) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Text(
+                    "Stop ${pickedIdx + 1}${if (pickedIdx == 0) " (Primary)" else ""} — tap to pin",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(380.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                ) {
+                    LocationPickerMapView(
+                        selectedLat = loc?.lat?.toDoubleOrNull(),
+                        selectedLng = loc?.lng?.toDoubleOrNull(),
+                        onLocationPicked = { lat, lng -> viewModel.onLocationPicked(pickedIdx, lat, lng) },
+                        modifier = Modifier.fillMaxSize()
                     )
                 }
-            } else if (!readOnly) {
+                Spacer(Modifier.height(12.dp))
+                Button(
+                    onClick = { pickingLocationIndex = -1 },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = BrandDark)
+                ) { Text("Confirm location") }
+                Spacer(Modifier.height(32.dp))
+            }
+        }
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        if (readOnly) {
+            FeedbackBanner("This event has already started — location cannot be changed.", FeedbackTone.Error)
+        }
+
+        // Route preview map (shown when at least one valid coordinate exists)
+        val hasValidCoords = uiState.locations.any { it.lat.toDoubleOrNull() != null && it.lng.toDoubleOrNull() != null }
+        if (hasValidCoords) {
+            StepCard {
+                FieldLabel("Route preview", helper = "Shows all stops connected in order.")
                 Spacer(Modifier.height(8.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                ) {
+                    MultiLocationMapView(
+                        locations = uiState.locations,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+        }
+
+        // Location stops list
+        StepCard {
+            FieldLabel(
+                "Stops",
+                helper = if (readOnly) "Locations locked for started events." else "Stop 1 is the primary venue. Add more stops to create a route."
+            )
+            Spacer(Modifier.height(12.dp))
+
+            uiState.locations.forEachIndexed { index, loc ->
+                LocationEntryCard(
+                    index = index,
+                    entry = loc,
+                    isPrimary = index == 0,
+                    canDelete = uiState.locations.size > 1 && !readOnly,
+                    readOnly = readOnly,
+                    onNameChange = { viewModel.onLocationNameChange(index, it) },
+                    onSetOnMap = { if (!readOnly) pickingLocationIndex = index },
+                    onDelete = { viewModel.removeLocation(index) },
+                    onToggleSegment = { viewModel.toggleSegmentFields(index) },
+                    onShowPicker = { field -> showPickerFor = Pair(index, field) },
+                    onSegmentDescriptionChange = { viewModel.onSegmentDescriptionChange(index, it) }
+                )
+                if (index < uiState.locations.size - 1) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp), thickness = 0.5.dp, color = MaterialTheme.colorScheme.outlineVariant)
+                }
+            }
+
+            uiState.locationError?.let {
+                Spacer(Modifier.height(8.dp))
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            if (!readOnly) {
+                Spacer(Modifier.height(12.dp))
+                OutlinedButton(
+                    onClick = { viewModel.addLocation() },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = BrandDark)
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Add another stop")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationEntryCard(
+    index: Int,
+    entry: LocationEntry,
+    isPrimary: Boolean,
+    canDelete: Boolean,
+    readOnly: Boolean,
+    onNameChange: (String) -> Unit,
+    onSetOnMap: () -> Unit,
+    onDelete: () -> Unit,
+    onToggleSegment: () -> Unit,
+    onShowPicker: (String) -> Unit,
+    onSegmentDescriptionChange: (String) -> Unit
+) {
+    Column {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Surface(
+                shape = CircleShape,
+                color = if (isPrimary) BrandDark else MaterialTheme.colorScheme.surfaceVariant,
+                modifier = Modifier.size(28.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(
+                        "${index + 1}",
+                        color = if (isPrimary) Color.White else MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                if (isPrimary) "Stop ${index + 1} · Primary" else "Stop ${index + 1}",
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+                modifier = Modifier.weight(1f)
+            )
+            if (canDelete) IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
+                Icon(Icons.Default.Delete, contentDescription = "Remove stop", modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.error)
+            }
+        }
+
+        Spacer(Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = entry.name,
+            onValueChange = { if (!readOnly) onNameChange(it) },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Place name") },
+            placeholder = { Text(if (isPrimary) "e.g. Main Venue, Istanbul" else "e.g. After-party venue") },
+            singleLine = true,
+            enabled = !readOnly
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            val lat = entry.lat.toDoubleOrNull()
+            val lng = entry.lng.toDoubleOrNull()
+            if (lat != null && lng != null) {
+                Surface(shape = RoundedCornerShape(8.dp), color = Color(0xFFF0EDE9), modifier = Modifier.weight(1f)) {
+                    Text(
+                        "📍 ${"%.4f".format(lat)}, ${"%.4f".format(lng)}",
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = BrandDark
+                    )
+                }
+            } else {
                 Text(
-                    "No location pinned yet — tap the map above.",
+                    "No location pinned",
                     style = MaterialTheme.typography.bodySmall,
-                    color = Color(0xFF9C9390)
+                    color = Color(0xFF9C9390),
+                    modifier = Modifier.weight(1f)
                 )
             }
+            if (!readOnly) {
+                Spacer(Modifier.width(8.dp))
+                OutlinedButton(
+                    onClick = onSetOnMap,
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                    modifier = Modifier.height(34.dp),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = BrandDark)
+                ) {
+                    Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier.size(14.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Set on map", fontSize = 12.sp)
+                }
+            }
+        }
+
+        if (!readOnly) {
+            Spacer(Modifier.height(6.dp))
+            TextButton(
+                onClick = onToggleSegment,
+                contentPadding = PaddingValues(0.dp),
+                modifier = Modifier.height(30.dp)
+            ) {
+                Icon(
+                    if (entry.showSegmentFields) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = BrandMid
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    if (entry.showSegmentFields) "Hide stop timing" else "Add stop timing",
+                    fontSize = 12.sp,
+                    color = BrandMid
+                )
+            }
+        }
+
+        if (entry.showSegmentFields) {
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = entry.segmentStartDate,
+                    onValueChange = {},
+                    modifier = Modifier.weight(1f),
+                    label = { Text("Start date") },
+                    placeholder = { Text("YYYY-MM-DD") },
+                    singleLine = true,
+                    enabled = !readOnly,
+                    readOnly = true,
+                    trailingIcon = {
+                        if (!readOnly) IconButton(onClick = { onShowPicker("startDate") }) {
+                            Icon(Icons.Default.DateRange, contentDescription = null, tint = BrandMid)
+                        }
+                    }
+                )
+                OutlinedTextField(
+                    value = entry.segmentStartTime,
+                    onValueChange = {},
+                    modifier = Modifier.weight(1f),
+                    label = { Text("Start time") },
+                    placeholder = { Text("HH:MM") },
+                    singleLine = true,
+                    enabled = !readOnly,
+                    readOnly = true,
+                    trailingIcon = {
+                        if (!readOnly) IconButton(onClick = { onShowPicker("startTime") }) {
+                            Icon(Icons.Default.AccessTime, contentDescription = null, tint = BrandMid)
+                        }
+                    }
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = entry.segmentEndDate,
+                    onValueChange = {},
+                    modifier = Modifier.weight(1f),
+                    label = { Text("End date") },
+                    placeholder = { Text("YYYY-MM-DD") },
+                    singleLine = true,
+                    enabled = !readOnly,
+                    readOnly = true,
+                    trailingIcon = {
+                        if (!readOnly) IconButton(onClick = { onShowPicker("endDate") }) {
+                            Icon(Icons.Default.DateRange, contentDescription = null, tint = BrandMid)
+                        }
+                    }
+                )
+                OutlinedTextField(
+                    value = entry.segmentEndTime,
+                    onValueChange = {},
+                    modifier = Modifier.weight(1f),
+                    label = { Text("End time") },
+                    placeholder = { Text("HH:MM") },
+                    singleLine = true,
+                    enabled = !readOnly,
+                    readOnly = true,
+                    trailingIcon = {
+                        if (!readOnly) IconButton(onClick = { onShowPicker("endTime") }) {
+                            Icon(Icons.Default.AccessTime, contentDescription = null, tint = BrandMid)
+                        }
+                    }
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = entry.segmentDescription,
+                onValueChange = { if (!readOnly) onSegmentDescriptionChange(it) },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Stop description (optional)") },
+                placeholder = { Text("e.g. Meet at the main entrance") },
+                maxLines = 2,
+                enabled = !readOnly
+            )
         }
     }
 }
@@ -1177,8 +1453,15 @@ private fun ReviewStep(uiState: CreateEventUiState, viewModel: CreateEventViewMo
 
         ReviewCard(title = "Location", onEdit = { viewModel.goToStep(2) },
             isComplete = uiState.stepCompleted(2)) {
-            Text(uiState.locationName.ifBlank { "No location" }, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
-            if (uiState.locationLat.isNotBlank()) Text("${uiState.locationLat}, ${uiState.locationLng}", style = MaterialTheme.typography.bodySmall, color = Color(0xFF78716C))
+            val primary = uiState.locations.firstOrNull()
+            Text(primary?.name?.ifBlank { "No location" } ?: "No location", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+            if (primary?.lat?.isNotBlank() == true) {
+                Text("${primary.lat}, ${primary.lng}", style = MaterialTheme.typography.bodySmall, color = Color(0xFF78716C))
+            }
+            val stopCount = uiState.locations.size
+            if (stopCount > 1) {
+                Text("+ ${stopCount - 1} more stop${if (stopCount - 1 == 1) "" else "s"}", style = MaterialTheme.typography.bodySmall, color = BrandMid)
+            }
         }
 
         ReviewCard(title = "Media", onEdit = { viewModel.goToStep(3) },

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventScreen.kt
@@ -940,15 +940,20 @@ private fun LocationStep(uiState: CreateEventUiState, viewModel: CreateEventView
             Spacer(Modifier.height(12.dp))
 
             uiState.locations.forEachIndexed { index, loc ->
+                val canReorder = uiState.locations.size > 1 && !readOnly
                 LocationEntryCard(
                     index = index,
                     entry = loc,
                     isPrimary = index == 0,
                     canDelete = uiState.locations.size > 1 && !readOnly,
+                    canMoveUp = canReorder && index > 0,
+                    canMoveDown = canReorder && index < uiState.locations.size - 1,
                     readOnly = readOnly,
                     onNameChange = { viewModel.onLocationNameChange(index, it) },
                     onSetOnMap = { if (!readOnly) pickingLocationIndex = index },
                     onDelete = { viewModel.removeLocation(index) },
+                    onMoveUp = { viewModel.moveLocation(index, index - 1) },
+                    onMoveDown = { viewModel.moveLocation(index, index + 1) },
                     onToggleSegment = { viewModel.toggleSegmentFields(index) },
                     onShowPicker = { field -> showPickerFor = Pair(index, field) },
                     onSegmentDescriptionChange = { viewModel.onSegmentDescriptionChange(index, it) }
@@ -985,10 +990,14 @@ private fun LocationEntryCard(
     entry: LocationEntry,
     isPrimary: Boolean,
     canDelete: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
     readOnly: Boolean,
     onNameChange: (String) -> Unit,
     onSetOnMap: () -> Unit,
     onDelete: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
     onToggleSegment: () -> Unit,
     onShowPicker: (String) -> Unit,
     onSegmentDescriptionChange: (String) -> Unit
@@ -1016,6 +1025,37 @@ private fun LocationEntryCard(
                 fontSize = 14.sp,
                 modifier = Modifier.weight(1f)
             )
+            // Reorder controls — moving a stop instantly re-numbers every card
+            // (issue #160 AC #1). The badge above reads `index + 1`, so reordering
+            // the underlying list updates the displayed numbers in one frame.
+            if (canMoveUp || canMoveDown) {
+                IconButton(
+                    onClick = onMoveUp,
+                    enabled = canMoveUp,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        Icons.Default.KeyboardArrowUp,
+                        contentDescription = "Move stop up",
+                        modifier = Modifier.size(20.dp),
+                        tint = if (canMoveUp) MaterialTheme.colorScheme.onSurface
+                               else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                    )
+                }
+                IconButton(
+                    onClick = onMoveDown,
+                    enabled = canMoveDown,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        Icons.Default.KeyboardArrowDown,
+                        contentDescription = "Move stop down",
+                        modifier = Modifier.size(20.dp),
+                        tint = if (canMoveDown) MaterialTheme.colorScheme.onSurface
+                               else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f),
+                    )
+                }
+            }
             if (canDelete) IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
                 Icon(Icons.Default.Delete, contentDescription = "Remove stop", modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.error)
             }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventViewModel.kt
@@ -10,6 +10,7 @@ import com.bounswe.group9.mobile.data.remote.EventDetailDto
 import com.bounswe.group9.mobile.data.remote.EventUpdateRequest
 import com.bounswe.group9.mobile.data.remote.EventImageDto
 import com.bounswe.group9.mobile.data.remote.LocationRequest
+import com.bounswe.group9.mobile.data.remote.SegmentRequest
 import com.bounswe.group9.mobile.data.remote.VenueMetadataRequest
 import com.bounswe.group9.mobile.data.repository.EventRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +36,18 @@ val EVENT_EDITOR_STEPS = listOf(
 
 enum class FeedbackTone { Success, Error, Info }
 
+data class LocationEntry(
+    val name: String = "",
+    val lat: String = "",
+    val lng: String = "",
+    val segmentStartDate: String = "",
+    val segmentStartTime: String = "",
+    val segmentEndDate: String = "",
+    val segmentEndTime: String = "",
+    val segmentDescription: String = "",
+    val showSegmentFields: Boolean = false
+)
+
 data class CreateEventUiState(
     val currentStep: Int = 0,
     // Step 0
@@ -49,10 +62,8 @@ data class CreateEventUiState(
     val endDate: String = "",
     val endTime: String = "",
     val scheduleConfirmed: Boolean = false,
-    // Step 2
-    val locationName: String = "",
-    val locationLat: String = "",
-    val locationLng: String = "",
+    // Step 2 — multi-location; first entry is always primary
+    val locations: List<LocationEntry> = listOf(LocationEntry()),
     // Step 3
     val selectedImageUris: List<Uri> = emptyList(),
     val uploadedImages: List<EventImageDto> = emptyList(),
@@ -97,8 +108,12 @@ data class CreateEventUiState(
     fun stepCompleted(step: Int): Boolean = when (step) {
         0 -> title.isNotBlank() && description.isNotBlank() && selectedCategoryIds.isNotEmpty()
         1 -> scheduleConfirmed && startDate.isNotBlank() && startTime.isNotBlank() && endDate.isNotBlank() && endTime.isNotBlank()
-        2 -> locationName.isNotBlank() && locationLat.toDoubleOrNull() != null && locationLng.toDoubleOrNull() != null
-        3 -> true  // Media is optional — backend allows publishing without images
+        2 -> {
+            val primary = locations.firstOrNull()
+            primary != null && primary.name.isNotBlank() &&
+                primary.lat.toDoubleOrNull() != null && primary.lng.toDoubleOrNull() != null
+        }
+        3 -> true
         4 -> true
         5 -> settingsConfirmed
         6 -> (0..5).all { stepCompleted(it) }
@@ -121,7 +136,6 @@ class CreateEventViewModel(
 
     fun init(token: String?, editEvent: EventDetailDto? = null) {
         currentToken = token
-        // Guard: unauthenticated users cannot access create/edit
         if (token == null) {
             update { copy(submitError = "You must be signed in to create or edit events.") }
             return
@@ -138,9 +152,24 @@ class CreateEventViewModel(
         fun parse(iso: String): Date? = try { isoParser.parse(iso) } catch (_: Exception) { null }
         val startD = parse(event.start_datetime)
         val endD = parse(event.end_datetime)
-        val loc = event.locations.firstOrNull { it.is_primary } ?: event.locations.firstOrNull()
-        // Check if event has already started — restricts schedule & location edits
         val alreadyStarted = startD != null && startD <= Date()
+
+        val segmentsByLocId = event.segments?.groupBy { it.location_id } ?: emptyMap()
+        val locEntries = event.locations.sortedBy { it.order_index }.map { loc ->
+            val seg = segmentsByLocId[loc.id]?.firstOrNull()
+            LocationEntry(
+                name = loc.name,
+                lat = loc.latitude.toString(),
+                lng = loc.longitude.toString(),
+                segmentStartDate = seg?.let { parseIsoDate(it.start_datetime, isoParser, dateFmt) } ?: "",
+                segmentStartTime = seg?.let { parseIsoTime(it.start_datetime, isoParser, timeFmt) } ?: "",
+                segmentEndDate = seg?.let { parseIsoDate(it.end_datetime, isoParser, dateFmt) } ?: "",
+                segmentEndTime = seg?.let { parseIsoTime(it.end_datetime, isoParser, timeFmt) } ?: "",
+                segmentDescription = seg?.description ?: "",
+                showSegmentFields = seg != null
+            )
+        }.ifEmpty { listOf(LocationEntry()) }
+
         update {
             copy(
                 isEditMode = true, editEventId = event.id, persistedEventId = event.id,
@@ -149,7 +178,7 @@ class CreateEventViewModel(
                 startTime = startD?.let { timeFmt.format(it) } ?: "",
                 endDate = endD?.let { dateFmt.format(it) } ?: "",
                 endTime = endD?.let { timeFmt.format(it) } ?: "",
-                locationName = loc?.name ?: "", locationLat = loc?.latitude?.toString() ?: "", locationLng = loc?.longitude?.toString() ?: "",
+                locations = locEntries,
                 visibility = event.visibility, isAgeRestricted = event.is_age_restricted,
                 attendeeLimitEnabled = event.attendee_limit != null, attendeeLimit = event.attendee_limit?.toString() ?: "",
                 selectedCategoryIds = event.categories.map { it.id }.toSet(),
@@ -163,6 +192,12 @@ class CreateEventViewModel(
             )
         }
     }
+
+    private fun parseIsoDate(iso: String, parser: SimpleDateFormat, fmt: SimpleDateFormat): String =
+        try { fmt.format(parser.parse(iso)!!) } catch (_: Exception) { "" }
+
+    private fun parseIsoTime(iso: String, parser: SimpleDateFormat, fmt: SimpleDateFormat): String =
+        try { fmt.format(parser.parse(iso)!!) } catch (_: Exception) { "" }
 
     private fun loadCategories() {
         update { copy(categoriesLoading = true) }
@@ -192,22 +227,62 @@ class CreateEventViewModel(
 
     fun onTitleChange(v: String) = update { copy(title = v, titleError = null) }
     fun onDescriptionChange(v: String) = update { copy(description = v, descriptionError = null) }
-    fun toggleCategory(id: String) { val c = _uiState.value.selectedCategoryIds; update { copy(selectedCategoryIds = if (id in c) c - id else c + id, categoryError = null) } }
+    fun toggleCategory(id: String) {
+        val c = _uiState.value.selectedCategoryIds
+        update { copy(selectedCategoryIds = if (id in c) c - id else c + id, categoryError = null) }
+    }
     fun onStartDateChange(v: String) = update { copy(startDate = v, startError = null) }
     fun onStartTimeChange(v: String) = update { copy(startTime = v, startError = null) }
     fun onEndDateChange(v: String) = update { copy(endDate = v, endError = null) }
     fun onEndTimeChange(v: String) = update { copy(endTime = v, endError = null) }
-    fun onLocationNameChange(v: String) = update { copy(locationName = v, locationError = null) }
-    fun onLocationLatChange(v: String) = update { copy(locationLat = v, locationError = null) }
-    fun onLocationLngChange(v: String) = update { copy(locationLng = v, locationError = null) }
-    /** Called when the user taps the map in Step 2 — sets both coordinates atomically. */
-    fun onLocationPicked(lat: Double, lng: Double) = update {
-        copy(
-            locationLat = lat.toString(),
-            locationLng = lng.toString(),
-            locationError = null
-        )
+
+    // ── Multi-location management ────────────────────────────────────────────────
+
+    fun onLocationNameChange(index: Int, name: String) = update {
+        copy(locations = locations.mapIndexed { i, l -> if (i == index) l.copy(name = name) else l }, locationError = null)
     }
+
+    fun onLocationPicked(index: Int, lat: Double, lng: Double) = update {
+        copy(locations = locations.mapIndexed { i, l ->
+            if (i == index) l.copy(lat = lat.toString(), lng = lng.toString()) else l
+        }, locationError = null)
+    }
+
+    fun addLocation() = update { copy(locations = locations + LocationEntry()) }
+
+    fun removeLocation(index: Int) = update {
+        if (locations.size <= 1) return@update this
+        copy(locations = locations.filterIndexed { i, _ -> i != index })
+    }
+
+    fun toggleSegmentFields(index: Int) = update {
+        copy(locations = locations.mapIndexed { i, l ->
+            if (i == index) l.copy(showSegmentFields = !l.showSegmentFields) else l
+        })
+    }
+
+    fun onSegmentStartDateChange(index: Int, date: String) = update {
+        copy(locations = locations.mapIndexed { i, l -> if (i == index) l.copy(segmentStartDate = date) else l })
+    }
+
+    fun onSegmentStartTimeChange(index: Int, time: String) = update {
+        copy(locations = locations.mapIndexed { i, l -> if (i == index) l.copy(segmentStartTime = time) else l })
+    }
+
+    fun onSegmentEndDateChange(index: Int, date: String) = update {
+        copy(locations = locations.mapIndexed { i, l -> if (i == index) l.copy(segmentEndDate = date) else l })
+    }
+
+    fun onSegmentEndTimeChange(index: Int, time: String) = update {
+        copy(locations = locations.mapIndexed { i, l -> if (i == index) l.copy(segmentEndTime = time) else l })
+    }
+
+    fun onSegmentDescriptionChange(index: Int, desc: String) = update {
+        copy(locations = locations.mapIndexed { i, l -> if (i == index) l.copy(segmentDescription = desc) else l })
+    }
+
+    // ── Venue & Accessibility ────────────────────────────────────────────────────
+
     fun onHealthRequirementsChange(v: String) = update { copy(healthRequirements = v) }
     fun onWheelchairAccessChange(v: Boolean) = update { copy(wheelchairAccess = v) }
     fun onAccessibleRestroomChange(v: Boolean) = update { copy(accessibleRestroom = v) }
@@ -224,12 +299,15 @@ class CreateEventViewModel(
     fun clearFeedback() = update { copy(feedbackMessage = null, submitError = null) }
 
     private fun validateCurrentStep(): Boolean = when (_uiState.value.currentStep) {
-        0 -> { val s = _uiState.value; var ok = true
+        0 -> {
+            val s = _uiState.value; var ok = true
             if (s.title.isBlank()) { update { copy(titleError = "Title is required") }; ok = false }
             if (s.description.isBlank()) { update { copy(descriptionError = "Description is required") }; ok = false }
             if (s.selectedCategoryIds.isEmpty()) { update { copy(categoryError = "Select at least one category") }; ok = false }
-            ok }
-        1 -> { val s = _uiState.value; var ok = true
+            ok
+        }
+        1 -> {
+            val s = _uiState.value; var ok = true
             if (s.startDate.isBlank() || s.startTime.isBlank()) { update { copy(startError = "Start date and time required") }; ok = false }
             if (s.endDate.isBlank() || s.endTime.isBlank()) { update { copy(endError = "End date and time required") }; ok = false }
             if (ok && !s.eventAlreadyStarted) {
@@ -240,12 +318,58 @@ class CreateEventViewModel(
                     update { copy(endError = "End time must be after start time") }; ok = false
                 }
             }
-            ok }
-        2 -> { val s = _uiState.value; var ok = true
-            if (s.locationName.isBlank()) { update { copy(locationError = "Location name required") }; ok = false }
-            val lat = s.locationLat.toDoubleOrNull(); val lng = s.locationLng.toDoubleOrNull()
-            if (lat == null || lat < -90 || lat > 90 || lng == null || lng < -180 || lng > 180) { update { copy(locationError = "Valid latitude and longitude required") }; ok = false }
-            ok }
+            ok
+        }
+        2 -> {
+            val s = _uiState.value; var ok = true
+            val primary = s.locations.firstOrNull()
+            if (primary == null || primary.name.isBlank()) { update { copy(locationError = "Location name required") }; ok = false }
+            if (ok) {
+                val lat = primary!!.lat.toDoubleOrNull(); val lng = primary.lng.toDoubleOrNull()
+                if (lat == null || lat < -90 || lat > 90 || lng == null || lng < -180 || lng > 180) {
+                    update { copy(locationError = "Valid latitude and longitude required for the primary location") }; ok = false
+                }
+            }
+            if (ok) {
+                val fmt = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                val eventStart = try { fmt.parse("${s.startDate} ${s.startTime}") } catch (_: Exception) { null }
+                val eventEnd   = try { fmt.parse("${s.endDate} ${s.endTime}") } catch (_: Exception) { null }
+
+                // Collect stops that have complete segment timing
+                val timedSegs = s.locations.mapIndexedNotNull { i, loc ->
+                    if (loc.segmentStartDate.isNotBlank() && loc.segmentStartTime.isNotBlank() &&
+                        loc.segmentEndDate.isNotBlank() && loc.segmentEndTime.isNotBlank()) {
+                        val segStart = try { fmt.parse("${loc.segmentStartDate} ${loc.segmentStartTime}") } catch (_: Exception) { null }
+                        val segEnd   = try { fmt.parse("${loc.segmentEndDate} ${loc.segmentEndTime}") } catch (_: Exception) { null }
+                        if (segStart != null && segEnd != null) Triple(i + 1, segStart, segEnd) else null
+                    } else null
+                }
+
+                for ((stopNum, segStart, segEnd) in timedSegs) {
+                    if (!segEnd.after(segStart)) {
+                        update { copy(locationError = "Stop $stopNum: end time must be after start time") }; ok = false; break
+                    }
+                    if (eventStart != null && segStart.before(eventStart)) {
+                        update { copy(locationError = "Stop $stopNum timing must not be before the event start") }; ok = false; break
+                    }
+                    if (eventEnd != null && segEnd.after(eventEnd)) {
+                        update { copy(locationError = "Stop $stopNum timing must not exceed the event end") }; ok = false; break
+                    }
+                }
+
+                // Consecutive timed stops must not overlap (stop N+1 must start at or after stop N ends)
+                if (ok) {
+                    for (i in 0 until timedSegs.size - 1) {
+                        val (prevNum, _, prevEnd) = timedSegs[i]
+                        val (nextNum, nextStart, _) = timedSegs[i + 1]
+                        if (nextStart.before(prevEnd)) {
+                            update { copy(locationError = "Stop $nextNum must start after Stop $prevNum ends") }; ok = false; break
+                        }
+                    }
+                }
+            }
+            ok
+        }
         else -> true
     }
 
@@ -279,12 +403,11 @@ class CreateEventViewModel(
         val token = currentToken ?: return
         val s = _uiState.value
 
-        // Pre-publish validation: find incomplete required steps (0,1,2,5)
         val missing = listOf(0, 1, 2, 5).filter { !s.stepCompleted(it) }
         if (missing.isNotEmpty()) {
             update {
                 copy(
-                    currentStep = 6, // go to Review to show what's missing
+                    currentStep = 6,
                     missingSteps = missing,
                     feedbackMessage = "Complete all required steps before publishing.",
                     feedbackTone = FeedbackTone.Error
@@ -325,7 +448,6 @@ class CreateEventViewModel(
         if (uris.isEmpty()) return
         update { copy(isUploadingImages = true, imageUploadError = null) }
         viewModelScope.launch {
-            // Auto-create draft first if it doesn't exist yet
             val eventId = _uiState.value.persistedEventId ?: run {
                 val s = _uiState.value
                 repository.createEvent(token, buildCreateRequest(s, "draft")).fold(
@@ -371,7 +493,6 @@ class CreateEventViewModel(
             val parser = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.US)
             val parsed = parser.parse("$date $time")
             if (parsed == null) {
-                // Return a valid future datetime fallback for drafts
                 return if (isEnd) "2099-12-31T23:59:00+00:00" else "2099-12-31T00:00:00+00:00"
             }
             val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US)
@@ -391,25 +512,49 @@ class CreateEventViewModel(
         quiet_friendly = s.quietFriendly
     )
 
+    private fun buildLocationRequests(s: CreateEventUiState): List<LocationRequest> =
+        s.locations.ifEmpty { listOf(LocationEntry()) }.mapIndexed { i, loc ->
+            LocationRequest(
+                name = loc.name.ifBlank { "Stop ${i + 1}" },
+                latitude = loc.lat.toDoubleOrNull() ?: 0.0,
+                longitude = loc.lng.toDoubleOrNull() ?: 0.0,
+                is_primary = (i == 0),
+                order_index = i
+            )
+        }
+
+    private fun buildSegmentRequests(s: CreateEventUiState): List<SegmentRequest>? {
+        val segs = s.locations.mapIndexedNotNull { i, loc ->
+            if (loc.segmentStartDate.isNotBlank() && loc.segmentStartTime.isNotBlank() &&
+                loc.segmentEndDate.isNotBlank() && loc.segmentEndTime.isNotBlank()) {
+                SegmentRequest(
+                    location_index = i,
+                    order_index = i,
+                    start_datetime = buildIso(loc.segmentStartDate, loc.segmentStartTime),
+                    end_datetime = buildIso(loc.segmentEndDate, loc.segmentEndTime, isEnd = true),
+                    description = loc.segmentDescription.ifBlank { null }
+                )
+            } else null
+        }
+        return if (segs.isNotEmpty()) segs else null
+    }
+
     private fun buildCreateRequest(s: CreateEventUiState, status: String): EventCreateRequest {
         val safeTitle = s.title.ifBlank { "Untitled Event" }
         val safeDesc = s.description.ifBlank { "No description provided yet." }
         val safeStart = buildIso(s.startDate, s.startTime)
         val safeEnd = buildIso(s.endDate, s.endTime, isEnd = true)
-        val safeLocName = s.locationName.ifBlank { "TBD" }
-        val safeLat = s.locationLat.toDoubleOrNull() ?: 0.0
-        val safeLng = s.locationLng.toDoubleOrNull() ?: 0.0
         val safeCategoryIds = s.selectedCategoryIds.toList().ifEmpty {
             s.availableCategories.firstOrNull()?.id?.let { listOf(it) } ?: emptyList()
         }
-
         return EventCreateRequest(
             title = safeTitle, description = safeDesc,
             start_datetime = safeStart, end_datetime = safeEnd,
             visibility = s.visibility, is_age_restricted = s.isAgeRestricted,
             attendee_limit = if (s.attendeeLimitEnabled) s.attendeeLimit.toIntOrNull() else null,
             status = status, category_ids = safeCategoryIds,
-            locations = listOf(LocationRequest(safeLocName, safeLat, safeLng)),
+            locations = buildLocationRequests(s),
+            segments = buildSegmentRequests(s),
             venue_metadata = buildVenueMetadata(s)
         )
     }
@@ -419,20 +564,17 @@ class CreateEventViewModel(
         val safeDesc = s.description.ifBlank { "No description provided yet." }
         val safeStart = buildIso(s.startDate, s.startTime)
         val safeEnd = buildIso(s.endDate, s.endTime, isEnd = true)
-        val safeLocName = s.locationName.ifBlank { "TBD" }
-        val safeLat = s.locationLat.toDoubleOrNull() ?: 0.0
-        val safeLng = s.locationLng.toDoubleOrNull() ?: 0.0
         val safeCategoryIds = s.selectedCategoryIds.toList().ifEmpty {
             s.availableCategories.firstOrNull()?.id?.let { listOf(it) } ?: emptyList()
         }
-
         return EventUpdateRequest(
             title = safeTitle, description = safeDesc,
             start_datetime = safeStart, end_datetime = safeEnd,
             visibility = s.visibility, is_age_restricted = s.isAgeRestricted,
             attendee_limit = if (s.attendeeLimitEnabled) s.attendeeLimit.toIntOrNull() else null,
             clear_attendee_limit = !s.attendeeLimitEnabled, category_ids = safeCategoryIds,
-            locations = listOf(LocationRequest(safeLocName, safeLat, safeLng)),
+            locations = buildLocationRequests(s),
+            segments = buildSegmentRequests(s),
             venue_metadata = buildVenueMetadata(s)
         )
     }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/createevent/CreateEventViewModel.kt
@@ -255,6 +255,20 @@ class CreateEventViewModel(
         copy(locations = locations.filterIndexed { i, _ -> i != index })
     }
 
+    /**
+     * Reorder a stop within the locations list. Index numbers shown in the UI
+     * are derived from the list position, so a reorder here automatically
+     * re-numbers the stops (issue #160 AC #1).
+     */
+    fun moveLocation(fromIndex: Int, toIndex: Int) = update {
+        if (fromIndex == toIndex) return@update this
+        if (fromIndex !in locations.indices || toIndex !in locations.indices) return@update this
+        val mutable = locations.toMutableList()
+        val moved = mutable.removeAt(fromIndex)
+        mutable.add(toIndex, moved)
+        copy(locations = mutable.toList(), locationError = null)
+    }
+
     fun toggleSegmentFields(index: Int) = update {
         copy(locations = locations.mapIndexed { i, l ->
             if (i == index) l.copy(showSegmentFields = !l.showSegmentFields) else l

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/MapView.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/MapView.kt
@@ -23,12 +23,17 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import coil.compose.AsyncImage
 import com.bounswe.group9.mobile.data.remote.EventListItemDto
+import com.bounswe.group9.mobile.data.remote.EventLocationDto
 import com.bounswe.group9.mobile.ui.common.formatEventDate
+import com.bounswe.group9.mobile.ui.createevent.LocationEntry
 import org.maplibre.android.MapLibre
 import org.maplibre.android.annotations.IconFactory
 import org.maplibre.android.annotations.MarkerOptions
+import org.maplibre.android.annotations.PolylineOptions
 import org.maplibre.android.camera.CameraPosition
+import org.maplibre.android.camera.CameraUpdateFactory
 import org.maplibre.android.geometry.LatLng
+import org.maplibre.android.geometry.LatLngBounds
 import org.maplibre.android.maps.MapView
 
 private const val MAP_STYLE = "https://tiles.openfreemap.org/styles/liberty"
@@ -309,6 +314,132 @@ fun LocationPickerMapView(
             }
         }
     }
+}
+
+// ── Multi-location map (used in Create Event and Event Detail) ─────────────────
+
+@Composable
+fun MultiLocationMapView(
+    locations: List<LocationEntry>,
+    modifier: Modifier = Modifier
+) {
+    val validPoints = locations.mapIndexedNotNull { i, loc ->
+        val lat = loc.lat.toDoubleOrNull(); val lng = loc.lng.toDoubleOrNull()
+        if (lat != null && lng != null) Triple(i + 1, lat, lng) else null
+    }
+    key(validPoints.joinToString { "${it.second},${it.third}" }) {
+        AndroidView(
+            factory = { context ->
+                MapLibre.getInstance(context)
+                MapView(context).apply {
+                    getMapAsync { map ->
+                        map.setStyle(MAP_STYLE) { _ ->
+                            setupMultiLocationMap(map, validPoints, context)
+                        }
+                    }
+                    onCreate(null)
+                }
+            },
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+fun EventDetailMapView(
+    locations: List<EventLocationDto>,
+    modifier: Modifier = Modifier
+) {
+    val sorted = remember(locations) { locations.sortedBy { it.order_index } }
+    val points = sorted.mapIndexed { i, loc -> Triple(i + 1, loc.latitude, loc.longitude) }
+    AndroidView(
+        factory = { context ->
+            MapLibre.getInstance(context)
+            MapView(context).apply {
+                getMapAsync { map ->
+                    map.setStyle(MAP_STYLE) { _ ->
+                        setupMultiLocationMap(map, points, context)
+                    }
+                }
+                onCreate(null)
+            }
+        },
+        modifier = modifier
+    )
+}
+
+private fun setupMultiLocationMap(
+    map: org.maplibre.android.maps.MapLibreMap,
+    points: List<Triple<Int, Double, Double>>,
+    context: android.content.Context
+) {
+    if (points.isEmpty()) {
+        map.cameraPosition = CameraPosition.Builder()
+            .target(LatLng(DEFAULT_LAT, DEFAULT_LNG))
+            .zoom(DEFAULT_ZOOM)
+            .build()
+        return
+    }
+
+    val latLngs = points.map { LatLng(it.second, it.third) }
+
+    points.forEach { (num, lat, lng) ->
+        map.addMarker(
+            MarkerOptions()
+                .position(LatLng(lat, lng))
+                .icon(IconFactory.getInstance(context).fromBitmap(createNumberedMarkerBitmap(num)))
+        )
+    }
+
+    if (latLngs.size >= 2) {
+        map.addPolyline(
+            PolylineOptions()
+                .addAll(latLngs)
+                .color(android.graphics.Color.parseColor("#493628"))
+                .width(3f)
+        )
+    }
+
+    if (latLngs.size == 1) {
+        map.cameraPosition = CameraPosition.Builder()
+            .target(latLngs[0])
+            .zoom(14.0)
+            .build()
+    } else {
+        val boundsBuilder = LatLngBounds.Builder()
+        latLngs.forEach { boundsBuilder.include(it) }
+        try {
+            val bounds = boundsBuilder.build()
+            map.easeCamera(CameraUpdateFactory.newLatLngBounds(bounds, 120))
+        } catch (_: Exception) {
+            map.cameraPosition = CameraPosition.Builder().target(latLngs[0]).zoom(10.0).build()
+        }
+    }
+}
+
+private fun createNumberedMarkerBitmap(number: Int): Bitmap {
+    val size = 80
+    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+    paint.color = android.graphics.Color.parseColor("#493628")
+    canvas.drawCircle(size / 2f, size / 2f - 8f, 28f, paint)
+
+    val path = android.graphics.Path()
+    path.moveTo(size / 2f - 10f, size / 2f + 18f)
+    path.lineTo(size / 2f + 10f, size / 2f + 18f)
+    path.lineTo(size / 2f, size / 2f + 38f)
+    path.close()
+    canvas.drawPath(path, paint)
+
+    paint.color = android.graphics.Color.WHITE
+    paint.textSize = 28f
+    paint.textAlign = Paint.Align.CENTER
+    paint.typeface = android.graphics.Typeface.DEFAULT_BOLD
+    canvas.drawText(number.toString(), size / 2f, size / 2f - 8f + 10f, paint)
+
+    return bitmap
 }
 
 private fun createMarkerBitmap(): Bitmap {

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
@@ -4,7 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -22,6 +25,7 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -46,8 +50,11 @@ import com.bounswe.group9.mobile.data.remote.AccessRequestResponseDto
 import com.bounswe.group9.mobile.data.remote.EventDetailDto
 import com.bounswe.group9.mobile.data.remote.EventLimitedDto
 import com.bounswe.group9.mobile.data.remote.EquipmentDto
+import com.bounswe.group9.mobile.data.remote.EventLocationDto
 import com.bounswe.group9.mobile.data.remote.InviteResponseDto
+import com.bounswe.group9.mobile.data.remote.SegmentDto
 import com.bounswe.group9.mobile.data.remote.VenueMetadataDto
+import com.bounswe.group9.mobile.ui.discovery.EventDetailMapView
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -494,17 +501,41 @@ private fun FullDetailContent(
             Spacer(Modifier.height(12.dp))
 
             // Locations
-            event.locations.sortedBy { it.order_index }.forEach { loc ->
+            event.locations.sortedBy { it.order_index }.forEachIndexed { i, loc ->
                 Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (event.locations.size > 1) {
+                        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.surfaceVariant, modifier = Modifier.size(20.dp)) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Text("${i + 1}", fontSize = 10.sp, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                        }
+                    } else {
+                        Icon(Icons.Default.LocationOn, contentDescription = null, modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
                     Spacer(Modifier.width(6.dp))
                     Text(
-                        loc.name + if (loc.is_primary) " (Primary)" else "",
+                        loc.name + if (loc.is_primary && event.locations.size > 1) " (Primary)" else "",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
                 Spacer(Modifier.height(4.dp))
+            }
+
+            // Route map for multi-location events
+            if (event.locations.size >= 2) {
+                Spacer(Modifier.height(8.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                ) {
+                    EventDetailMapView(
+                        locations = event.locations,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
             }
 
             Spacer(Modifier.height(12.dp))
@@ -543,6 +574,12 @@ private fun FullDetailContent(
             // Description
             SectionHeader("About")
             Text(event.description, style = MaterialTheme.typography.bodyMedium)
+
+            // Itinerary timeline
+            if (!event.segments.isNullOrEmpty()) {
+                Spacer(Modifier.height(16.dp))
+                ItinerarySection(segments = event.segments, locations = event.locations)
+            }
 
             // Venue Metadata
             if (event.venue_metadata != null) {
@@ -1067,6 +1104,77 @@ private fun AccessRequestRow(
 }
 
 @Composable
+private fun ItinerarySection(segments: List<SegmentDto>, locations: List<EventLocationDto>) {
+    SectionHeader("Itinerary")
+    val locationById = remember(locations) { locations.associateBy { it.id } }
+    val sorted = remember(segments) { segments.sortedBy { it.order_index } }
+    sorted.forEachIndexed { index, segment ->
+        val locName = locationById[segment.location_id]?.name ?: "Stop ${index + 1}"
+        ItineraryTimelineItem(
+            number = index + 1,
+            locationName = locName,
+            startDatetime = segment.start_datetime,
+            endDatetime = segment.end_datetime,
+            description = segment.description,
+            isLast = index == sorted.size - 1
+        )
+    }
+}
+
+@Composable
+private fun ItineraryTimelineItem(
+    number: Int,
+    locationName: String,
+    startDatetime: String,
+    endDatetime: String,
+    description: String?,
+    isLast: Boolean
+) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.width(28.dp)
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.tertiary,
+                modifier = Modifier.size(24.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text("$number", color = MaterialTheme.colorScheme.onTertiary, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                }
+            }
+            if (!isLast) {
+                Box(
+                    modifier = Modifier
+                        .width(2.dp)
+                        .height(44.dp)
+                        .background(MaterialTheme.colorScheme.outlineVariant)
+                )
+            }
+        }
+        Spacer(Modifier.width(12.dp))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(bottom = if (isLast) 0.dp else 4.dp)
+        ) {
+            Text(locationName, fontWeight = FontWeight.SemiBold, fontSize = 14.sp)
+            Text(
+                "${formatSegmentTime(startDatetime)} – ${formatSegmentTime(endDatetime)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (!description.isNullOrBlank()) {
+                Spacer(Modifier.height(2.dp))
+                Text(description, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (!isLast) Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
 private fun SectionHeader(title: String) {
     Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
     Spacer(Modifier.height(6.dp))
@@ -1082,17 +1190,33 @@ private fun VenueMetadataSection(venue: VenueMetadataDto) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun EquipmentSection(equipment: List<EquipmentDto>) {
     SectionHeader("Equipment")
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
         equipment.forEach { eq ->
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    if (eq.is_required) "• ${eq.item_name} (Required)" else "• ${eq.item_name} (Optional)",
-                    style = MaterialTheme.typography.bodyMedium
+            AssistChip(
+                onClick = {},
+                label = { Text(eq.item_name, fontSize = 12.sp) },
+                leadingIcon = {
+                    Icon(
+                        if (eq.is_required) Icons.Default.Star else Icons.Default.Info,
+                        contentDescription = if (eq.is_required) "Required" else "Optional",
+                        modifier = Modifier.size(14.dp),
+                        tint = if (eq.is_required) MaterialTheme.colorScheme.error
+                               else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = if (eq.is_required)
+                        MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.4f)
+                    else MaterialTheme.colorScheme.surfaceVariant
                 )
-            }
+            )
         }
     }
 }
@@ -1108,6 +1232,16 @@ private fun InfoRow(label: String, value: String) {
 // endregion
 
 // region Helpers
+
+private fun formatSegmentTime(iso: String): String {
+    return try {
+        val parser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.getDefault())
+        val display = SimpleDateFormat("MMM d, HH:mm", Locale.getDefault())
+        display.timeZone = TimeZone.getDefault()
+        val date = parser.parse(iso)
+        if (date != null) display.format(date) else iso
+    } catch (_: Exception) { iso }
+}
 
 private fun formatDateRange(start: String, end: String): String {
     return try {


### PR DESCRIPTION
Closes #160 
## Summary

Implements the mobile UI for issue #160, closing the client-side gap left by the backend PR #265 (issue #149).
Hosts can now build ordered multi-stop event routes in the Create/Edit form, and attendees see an interactive
route map and itinerary timeline on the Event Detail screen.

---

## What was built

### Data layer
- **`SegmentRequest`** added to `ApiService.kt` — sent on create/update when stop timing is filled in.
- **`SegmentDto`** added to `EventDetailDto.kt`; `EventDetailDto.segments` field added (nullable, backward-compatible with events that have no segments).
- `EventCreateRequest.segments` and `EventUpdateRequest.segments` fields added (both optional, `null` = no change).

### Create / Edit Event — Location step (Step 2)
- **Multi-stop list**: replaced the single-venue form with a reorderable list of `LocationEntry` cards. Stop 1 is always the primary venue.
- **Numbered badge**: each stop shows its order number in a filled circle (primary = brand colour).
- **Per-stop map picker**: tapping "Set on map" opens a `ModalBottomSheet` containing the existing `LocationPickerMapView` scoped to that stop. Confirming writes coordinates back to the correct entry.
- **Route preview map**: once at least one stop is pinned, a `MultiLocationMapView` (200 dp) renders above the list showing all pins with their numbers and a polyline connecting them in stop order. The map re-renders automatically whenever a coordinate changes.
- **Add / remove stops**: "Add another stop" appends an empty entry; the 🗑 button removes any stop except when only one remains.
- **Optional stop timing (segments)**: each stop has a collapsible "Add stop timing" section — start date, start time, end date, end time (all via date/time pickers) and an optional description field. When filled in, the data is sent as a `SegmentRequest` on save/publish.
- **Segment validation** (enforced on "Next"):
  - Stop end time must be after start time.
  - Each segment must fall within the event's overall start–end window.
  - Consecutive stops with timing must not overlap — Stop N+1 must start at or after Stop N ends.
- **Review step** updated to show the primary stop name + coordinates and a "+N more stops" indicator when multiple stops exist.

### Maps — `MapView.kt`
- **`MultiLocationMapView`**: Compose wrapper around a MapLibre `MapView` that accepts a `List<LocationEntry>` (from the create form), renders numbered marker bitmaps, draws a `PolylineOptions` route, and fits the camera to all points. Uses `key(coordinates)` to trigger a clean re-render when the stop list changes.
- **`EventDetailMapView`**: same rendering logic, but accepts `List<EventLocationDto>` (from the detail response) and is read-only.
- **`createNumberedMarkerBitmap(n)`**: new helper that draws the number directly onto the existing pin bitmap shape instead of the hollow white dot.
- Both composables share a private `setupMultiLocationMap` that handles markers, polyline, and camera bounds in one place.

### Event Detail screen
- **Location list**: numbered circles replace the `LocationOn` icon for multi-stop events so order is visually clear. The `(Primary)` label is only shown when there are multiple stops.
- **Route map**: for events with ≥ 2 locations a 200 dp `EventDetailMapView` is rendered below the stop list, showing the full route.
- **Itinerary timeline**: `ItinerarySection` composable renders a vertical timeline (filled dot → connecting line → next dot) when `event.segments` is non-empty. Each row shows the stop name (resolved from `locations` by `location_id`), the formatted time window (`MMM d, HH:mm – HH:mm`), and the optional description.
- **Equipment chips**: `EquipmentSection` replaced bullet-list text with `AssistChip` components in a `FlowRow`. Required items get a red star icon and a tinted error-container background; optional items get an info icon on a surface-variant background.

---

## Files changed

| File | Change |
|------|--------|
| `ApiService.kt` | `SegmentRequest` DTO; `segments` field on create/update requests |
| `EventDetailDto.kt` | `SegmentDto` DTO; `segments: List<SegmentDto>?` on `EventDetailDto` |
| `CreateEventViewModel.kt` | `LocationEntry` data class; multi-stop state + actions; segment validation in step 2 |
| `MapView.kt` | `MultiLocationMapView`, `EventDetailMapView`, `setupMultiLocationMap`, `createNumberedMarkerBitmap` |
| `CreateEventScreen.kt` | New `LocationStep` (multi-stop list + map picker sheet); updated `LocationEntryCard`; updated Review step |
| `EventDetailScreen.kt` | Route map, itinerary timeline, numbered stop list, equipment chips |

## Test plan

- [ ] Create event with 3 stops — verify numbered pins + polyline appear in route preview after each coordinate is set
- [ ] Add stop timing to stops 1 and 2 within the event window — verify save succeeds
- [ ] Set stop 1 timing before event start — verify error "Stop 1 timing must not be before the event start"
- [ ] Set stop 2 timing to overlap with stop 1 — verify error "Stop 2 must start after Stop 1 ends"
- [ ] Delete a middle stop — verify list re-numbers and map updates
- [ ] Open a multi-location event detail — verify route map with numbered pins and polyline appears
- [ ] Open an event with segments — verify Itinerary timeline section renders correctly
- [ ] Open an event without segments — verify Itinerary section is absent
- [ ] Open an event with equipment — verify chip layout with correct required/optional styling
- [ ] Single-location event detail — verify no map is shown, no numbered circle, existing layout unchanged

