### PR TITLE
feat: similar-events-under-each-event-backend-mobil

### DIFF
--- a/backend/app/repositories/event.py
+++ b/backend/app/repositories/event.py
@@ -486,7 +486,13 @@ def get_primary_images_for_events(db: Client, event_ids: list[str]) -> dict[str,
 
 
 def get_similar_candidates(db: Client, event_id: str, limit: int = 30) -> list[dict]:
-    """Return published/updated future public events excluding the source event."""
+    """Return published/updated future events (public + private) excluding the source.
+
+    Private events are included to match Discovery's behaviour: they appear in
+    the list with a teaser (no description) so the viewer can still tap through
+    and request access. The service layer applies the same private-aware
+    redaction as list_events when building the response.
+    """
     now = datetime.now(UTC)
     result = (
         db.table("events")
@@ -494,7 +500,6 @@ def get_similar_candidates(db: Client, event_id: str, limit: int = 30) -> list[d
         .in_("status", ["published", "updated"])
         .gte("end_datetime", now.isoformat())
         .neq("id", event_id)
-        .eq("visibility", "public")
         .order("start_datetime")
         .order("id")
         .limit(limit)

--- a/backend/app/repositories/event.py
+++ b/backend/app/repositories/event.py
@@ -483,3 +483,21 @@ def get_primary_images_for_events(db: Client, event_ids: list[str]) -> dict[str,
         if eid not in images:
             images[eid] = row["image_url"]
     return images
+
+
+def get_similar_candidates(db: Client, event_id: str, limit: int = 30) -> list[dict]:
+    """Return published/updated future public events excluding the source event."""
+    now = datetime.now(UTC)
+    result = (
+        db.table("events")
+        .select(_EVENT_COLS)
+        .in_("status", ["published", "updated"])
+        .gte("end_datetime", now.isoformat())
+        .neq("id", event_id)
+        .eq("visibility", "public")
+        .order("start_datetime")
+        .order("id")
+        .limit(limit)
+        .execute()
+    )
+    return result.data or []

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -18,6 +18,7 @@ from app.models.event import (
     EventDetailResponse,
     EventImageResponse,
     EventLimitedResponse,
+    EventListItemResponse,
     EventListResponse,
     EventUpdateRequest,
     StatusChangeRequest,
@@ -30,6 +31,7 @@ from app.services.event import (
     create_event,
     delete_event,
     get_event_detail,
+    get_similar_events,
     update_event,
 )
 from app.services.event import (
@@ -404,3 +406,22 @@ def delete_image_endpoint(
     db = get_supabase()
     delete_image_svc(db, str(event_id), str(image_id), user_id)
     return MessageResponse(message="Image deleted successfully")
+
+
+@router.get(
+    "/{event_id}/similar",
+    response_model=list[EventListItemResponse],
+    summary="Get similar events",
+    description=(
+        "Returns up to 5 public published/updated future events ranked by "
+        "category overlap (×3), same host (×2), and proximity ≤50 km (×1). "
+        "Optional auth: bookmarked state is populated when a token is provided."
+    ),
+    responses={**NOT_FOUND_RESPONSE},
+)
+def get_similar_events_endpoint(
+    event_id: UUID,
+    user_id: str | None = Depends(_optional_user_id),
+):
+    db = get_supabase()
+    return get_similar_events(db, str(event_id), user_id)

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -996,3 +996,88 @@ def list_events_geojson(
         features.append(GeoJSONFeature(geometry=point, properties=properties))
 
     return GeoJSONFeatureCollection(features=features)
+
+
+def get_similar_events(
+    db: Client,
+    event_id: str,
+    user_id: str | None = None,
+    limit: int = 5,
+) -> list[EventListItemResponse]:
+    """Return up to `limit` scored similar public published/updated future events."""
+    source = event_repo.get_event_by_id(db, event_id)
+    if not source:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    source_categories = event_repo.get_event_categories(db, event_id)
+    source_cat_ids = {c["id"] for c in source_categories}
+
+    source_locs = db.table("event_locations").select("latitude,longitude").eq("event_id", event_id).eq("is_primary", True).execute()
+    source_lat = source_lng = None
+    if source_locs.data:
+        source_lat = source_locs.data[0].get("latitude")
+        source_lng = source_locs.data[0].get("longitude")
+
+    candidates = event_repo.get_similar_candidates(db, event_id, limit=30)
+    if not candidates:
+        return []
+
+    candidate_ids = [c["id"] for c in candidates]
+    cats_by_event = event_repo.get_categories_for_events(db, candidate_ids)
+    locs_by_event = event_repo.get_primary_locations_for_events(db, candidate_ids)
+
+    scored = []
+    for cand in candidates:
+        cid = cand["id"]
+        cand_cat_ids = {c["id"] for c in cats_by_event.get(cid, [])}
+        overlap = len(source_cat_ids & cand_cat_ids)
+        host_match = 1 if cand["host_id"] == source["host_id"] else 0
+
+        proximity_bonus = 0
+        if source_lat is not None and source_lng is not None:
+            loc = locs_by_event.get(cid)
+            if loc and loc.get("latitude") is not None and loc.get("longitude") is not None:
+                dist = _haversine_km(source_lat, source_lng, loc["latitude"], loc["longitude"])
+                if dist <= 50:
+                    proximity_bonus = 1
+
+        score = overlap * 3 + host_match * 2 + proximity_bonus
+        scored.append((score, cand))
+
+    scored.sort(key=lambda x: (-x[0], x[1]["start_datetime"], x[1]["id"]))
+    top = [c for _, c in scored[:limit]]
+    top_ids = [c["id"] for c in top]
+
+    locations_by_event = event_repo.get_primary_locations_for_events(db, top_ids)
+    images_by_event = event_repo.get_primary_images_for_events(db, top_ids)
+    bookmark_counts = bookmark_repo.get_bookmark_counts_for_events(db, top_ids)
+
+    is_bookmarked_map: set[str] = set()
+    if user_id:
+        is_bookmarked_map = bookmark_repo.get_bookmark_status_for_events(db, user_id, top_ids)
+
+    items = []
+    for event in top:
+        eid = event["id"]
+        items.append(EventListItemResponse(
+            id=eid,
+            host_id=event["host_id"],
+            title=event["title"],
+            description=event["description"],
+            start_datetime=event["start_datetime"],
+            end_datetime=event["end_datetime"],
+            visibility=event["visibility"],
+            is_age_restricted=event["is_age_restricted"],
+            attendee_limit=event["attendee_limit"],
+            attendee_count=event["attendee_count"],
+            status=event["status"],
+            is_bookmarked=(eid in is_bookmarked_map) if user_id else None,
+            going_count=event["attendee_count"],
+            bookmark_count=bookmark_counts.get(eid, 0),
+            is_full=(event["attendee_count"] >= event["attendee_limit"]) if event["attendee_limit"] is not None else None,
+            categories=cats_by_event.get(eid, []),
+            primary_location=locations_by_event.get(eid),
+            primary_image_url=images_by_event.get(eid),
+        ))
+
+    return items

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -1052,18 +1052,31 @@ def get_similar_events(
     images_by_event = event_repo.get_primary_images_for_events(db, top_ids)
     bookmark_counts = bookmark_repo.get_bookmark_counts_for_events(db, top_ids)
 
+    # Mirror list_events: private-aware redaction + access state batch lookups.
     is_bookmarked_map: set[str] = set()
+    access_request_status_map: dict[str, str] = {}
+    access_granted_event_ids: set[str] = set()
     if user_id:
         is_bookmarked_map = bookmark_repo.get_bookmark_status_for_events(db, user_id, top_ids)
+        access_request_status_map = invite_repo.get_access_request_status_for_events(
+            db, user_id, top_ids,
+        )
+        access_granted_event_ids = invite_repo.get_access_granted_event_ids(
+            db, user_id, top_ids,
+        )
 
     items = []
     for event in top:
         eid = event["id"]
+        is_private = event["visibility"] == "private"
+        # Hide description for private events and for guests viewing public
+        # events — same teaser rule Discovery uses (`list_events`).
+        show_preview_details = user_id is not None and not is_private
         items.append(EventListItemResponse(
             id=eid,
             host_id=event["host_id"],
             title=event["title"],
-            description=event["description"],
+            description=event["description"] if show_preview_details else None,
             start_datetime=event["start_datetime"],
             end_datetime=event["end_datetime"],
             visibility=event["visibility"],
@@ -1072,10 +1085,17 @@ def get_similar_events(
             attendee_count=event["attendee_count"],
             status=event["status"],
             is_bookmarked=(eid in is_bookmarked_map) if user_id else None,
+            access_request_status=access_request_status_map.get(eid) if user_id else None,
+            has_access=(
+                True
+                if user_id and event["host_id"] == user_id
+                else eid in access_granted_event_ids
+            ) if user_id else None,
             going_count=event["attendee_count"],
             bookmark_count=bookmark_counts.get(eid, 0),
             is_full=(event["attendee_count"] >= event["attendee_limit"]) if event["attendee_limit"] is not None else None,
             categories=cats_by_event.get(eid, []),
+            # Location visible to all (needed for map view, even private events) — Discovery parity.
             primary_location=locations_by_event.get(eid),
             primary_image_url=images_by_event.get(eid),
         ))

--- a/backend/tests/test_similar_events_unit.py
+++ b/backend/tests/test_similar_events_unit.py
@@ -1,0 +1,182 @@
+"""Unit tests for the similar events service function.
+
+All DB calls are mocked — no network/Supabase required.
+"""
+
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.event import get_similar_events
+
+# Stable category UUIDs shared across tests
+CAT1 = str(uuid4())
+CAT2 = str(uuid4())
+CAT3 = str(uuid4())
+
+
+def _cat_row(cid: str) -> dict:
+    return {"id": cid, "name": f"cat-{cid[:8]}", "is_predefined": True, "is_approved": True}
+
+
+def _event(
+    event_id: str | None = None,
+    host_id: str | None = None,
+    cat_ids: list[str] | None = None,
+    lat: float | None = None,
+    lng: float | None = None,
+    hours_from_now: int = 24,
+) -> dict:
+    now = datetime.now(UTC)
+    return {
+        "id": event_id or str(uuid4()),
+        "host_id": host_id or str(uuid4()),
+        "title": "Event",
+        "description": "desc",
+        "start_datetime": (now + timedelta(hours=hours_from_now)).isoformat(),
+        "end_datetime": (now + timedelta(hours=hours_from_now + 2)).isoformat(),
+        "visibility": "public",
+        "is_age_restricted": False,
+        "attendee_limit": None,
+        "attendee_count": 0,
+        "status": "published",
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+        "_cat_ids": cat_ids or [],
+        "_lat": lat,
+        "_lng": lng,
+    }
+
+
+@contextmanager
+def _mock_db_for(source: dict, candidates: list[dict]):
+    """Build a mock Supabase Client whose queries return scripted data."""
+    db = MagicMock()
+
+    source_cat_rows = [_cat_row(cid) for cid in source["_cat_ids"]]
+    source_loc_rows = (
+        [{"latitude": source["_lat"], "longitude": source["_lng"]}]
+        if source["_lat"] is not None else []
+    )
+
+    cats_by_event: dict[str, list[dict]] = {}
+    locs_by_event: dict[str, dict] = {}
+    for cand in candidates:
+        cats_by_event[cand["id"]] = [_cat_row(cid) for cid in cand["_cat_ids"]]
+        if cand["_lat"] is not None:
+            locs_by_event[cand["id"]] = {
+                "latitude": cand["_lat"],
+                "longitude": cand["_lng"],
+                "event_id": cand["id"],
+                "id": str(uuid4()),
+                "name": "Location",
+                "is_primary": True,
+                "order_index": 0,
+            }
+
+    clean_candidates = [{k: v for k, v in c.items() if not k.startswith("_")} for c in candidates]
+    clean_source = {k: v for k, v in source.items() if not k.startswith("_")}
+
+    table_mock = MagicMock()
+    table_mock.select.return_value.eq.return_value.eq.return_value.execute.return_value.data = source_loc_rows
+    db.table.return_value = table_mock
+
+    with (
+        patch("app.services.event.event_repo.get_event_by_id", return_value=clean_source),
+        patch("app.services.event.event_repo.get_event_categories", return_value=source_cat_rows),
+        patch("app.services.event.event_repo.get_similar_candidates", return_value=clean_candidates),
+        patch("app.services.event.event_repo.get_categories_for_events", return_value=cats_by_event),
+        patch("app.services.event.event_repo.get_primary_locations_for_events", return_value=locs_by_event),
+        patch("app.services.event.event_repo.get_primary_images_for_events", return_value={}),
+        patch("app.services.event.bookmark_repo.get_bookmark_counts_for_events", return_value={}),
+        patch("app.services.event.bookmark_repo.get_bookmark_status_for_events", return_value=set()),
+    ):
+        yield db
+
+
+class TestGetSimilarEvents:
+    def test_raises_404_when_source_not_found(self):
+        db = MagicMock()
+        with patch("app.services.event.event_repo.get_event_by_id", return_value=None):
+            with pytest.raises(HTTPException) as exc:
+                get_similar_events(db, "nonexistent-id")
+        assert exc.value.status_code == 404
+
+    def test_returns_empty_when_no_candidates(self):
+        source = _event(cat_ids=[CAT1])
+        with _mock_db_for(source, []) as db:
+            result = get_similar_events(db, source["id"])
+        assert result == []
+
+    def test_category_overlap_drives_ranking(self):
+        source_id = str(uuid4())
+        source = _event(event_id=source_id, cat_ids=[CAT1, CAT2, CAT3])
+
+        high_overlap = _event(event_id=str(uuid4()), cat_ids=[CAT1, CAT2, CAT3])
+        low_overlap = _event(event_id=str(uuid4()), cat_ids=[CAT1])
+
+        with _mock_db_for(source, [low_overlap, high_overlap]) as db:
+            result = get_similar_events(db, source_id)
+
+        assert len(result) == 2
+        assert str(result[0].id) == high_overlap["id"]
+
+    def test_host_match_contributes_to_score(self):
+        host = str(uuid4())
+        source = _event(host_id=host, cat_ids=[CAT1])
+
+        same_host_no_cats = _event(host_id=host, cat_ids=[])       # score = 2
+        diff_host_one_cat = _event(host_id=str(uuid4()), cat_ids=[CAT1])  # score = 3
+
+        with _mock_db_for(source, [same_host_no_cats, diff_host_one_cat]) as db:
+            result = get_similar_events(db, source["id"])
+
+        # diff_host_one_cat (score=3) should rank above same_host_no_cats (score=2)
+        assert str(result[0].id) == diff_host_one_cat["id"]
+
+    def test_proximity_bonus_within_50km(self):
+        source = _event(cat_ids=[], lat=41.0, lng=28.9)  # Istanbul
+
+        nearby = _event(cat_ids=[], lat=41.05, lng=28.95)  # ~6 km → bonus (+1)
+        far_away = _event(cat_ids=[], lat=50.0, lng=14.0)  # Prague → no bonus
+
+        with _mock_db_for(source, [far_away, nearby]) as db:
+            result = get_similar_events(db, source["id"])
+
+        assert str(result[0].id) == nearby["id"]
+
+    def test_limits_results_to_five(self):
+        source = _event(cat_ids=[CAT1])
+        candidates = [_event(cat_ids=[CAT1]) for _ in range(10)]
+
+        with _mock_db_for(source, candidates) as db:
+            result = get_similar_events(db, source["id"])
+
+        assert len(result) <= 5
+
+    def test_guest_has_no_bookmark_state(self):
+        source = _event(cat_ids=[CAT1])
+        cand = _event(cat_ids=[CAT1])
+
+        with _mock_db_for(source, [cand]) as db:
+            result = get_similar_events(db, source["id"], user_id=None)
+
+        assert result[0].is_bookmarked is None
+
+    def test_authenticated_user_gets_bookmark_state(self):
+        source = _event(cat_ids=[CAT1])
+        cand = _event(cat_ids=[CAT1])
+        user_id = str(uuid4())
+
+        with _mock_db_for(source, [cand]) as db:
+            with patch(
+                "app.services.event.bookmark_repo.get_bookmark_status_for_events",
+                return_value={cand["id"]},
+            ):
+                result = get_similar_events(db, source["id"], user_id=user_id)
+
+        assert result[0].is_bookmarked is True

--- a/backend/tests/test_similar_events_unit.py
+++ b/backend/tests/test_similar_events_unit.py
@@ -94,6 +94,12 @@ def _mock_db_for(source: dict, candidates: list[dict]):
         patch("app.services.event.event_repo.get_primary_images_for_events", return_value={}),
         patch("app.services.event.bookmark_repo.get_bookmark_counts_for_events", return_value={}),
         patch("app.services.event.bookmark_repo.get_bookmark_status_for_events", return_value=set()),
+        # Discovery-parity: similar events surfaces private listings with a
+        # teaser; the access-state batch lookups must be mocked even when
+        # tests don't pass user_id (the service only calls them when user_id
+        # is set, so default empties keep guest-flow tests intact).
+        patch("app.services.event.invite_repo.get_access_request_status_for_events", return_value={}),
+        patch("app.services.event.invite_repo.get_access_granted_event_ids", return_value=set()),
     ):
         yield db
 
@@ -180,3 +186,59 @@ class TestGetSimilarEvents:
                 result = get_similar_events(db, source["id"], user_id=user_id)
 
         assert result[0].is_bookmarked is True
+
+    def test_private_candidate_appears_with_redacted_description(self):
+        # Discovery parity: private events show up in the list with a teaser
+        # (no description) so the viewer can tap through and request access,
+        # rather than being filtered out entirely.
+        source = _event(cat_ids=[CAT1])
+        private_cand = _event(cat_ids=[CAT1])
+        private_cand["visibility"] = "private"
+        private_cand["description"] = "secret guest list"
+        user_id = str(uuid4())
+
+        with _mock_db_for(source, [private_cand]) as db:
+            result = get_similar_events(db, source["id"], user_id=user_id)
+
+        # Private candidate is surfaced (not filtered out)
+        assert len(result) == 1
+        assert str(result[0].id) == private_cand["id"]
+        # ...but description is redacted
+        assert result[0].description is None
+        # visibility flag is preserved so the client can render a "private" badge
+        assert result[0].visibility == "private"
+
+    def test_private_candidate_visible_to_guest_with_teaser(self):
+        # Same redaction applies for unauthenticated viewers.
+        source = _event(cat_ids=[CAT1])
+        private_cand = _event(cat_ids=[CAT1])
+        private_cand["visibility"] = "private"
+        private_cand["description"] = "secret guest list"
+
+        with _mock_db_for(source, [private_cand]) as db:
+            result = get_similar_events(db, source["id"], user_id=None)
+
+        assert len(result) == 1
+        assert result[0].description is None
+        # Guests have no notion of access state — `has_access` and
+        # `access_request_status` remain None for them.
+        assert result[0].has_access is None
+        assert result[0].access_request_status is None
+
+    def test_authed_user_with_access_grant_sees_has_access_true(self):
+        # An authenticated user with a granted access record on a private
+        # candidate should see has_access=True so the UI can route them
+        # straight into the event without prompting a request.
+        source = _event(cat_ids=[CAT1])
+        private_cand = _event(cat_ids=[CAT1])
+        private_cand["visibility"] = "private"
+        user_id = str(uuid4())
+
+        with _mock_db_for(source, [private_cand]) as db:
+            with patch(
+                "app.services.event.invite_repo.get_access_granted_event_ids",
+                return_value={private_cand["id"]},
+            ):
+                result = get_similar_events(db, source["id"], user_id=user_id)
+
+        assert result[0].has_access is True

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
@@ -322,6 +322,12 @@ interface ApiService {
         @Header("Authorization") token: String? = null
     ): Response<JsonObject>
 
+    @GET("events/{event_id}/similar")
+    suspend fun getSimilarEvents(
+        @Path("event_id") eventId: String,
+        @Header("Authorization") token: String? = null
+    ): Response<List<EventListItemDto>>
+
     // ── Event CRUD ──
 
     @POST("events")

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/repository/EventRepository.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/repository/EventRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.bounswe.group9.mobile.data.remote.AttendanceRequest
 import com.bounswe.group9.mobile.data.remote.CategoryDto
 import com.bounswe.group9.mobile.data.remote.EventDetailDto
+import com.bounswe.group9.mobile.data.remote.EventListItemDto
 import com.bounswe.group9.mobile.data.remote.EventLimitedDto
 import com.bounswe.group9.mobile.data.remote.EventListResponse
 import com.bounswe.group9.mobile.data.remote.RetrofitProvider
@@ -75,6 +76,25 @@ class EventRepository {
             }
         } catch (e: Exception) {
             Log.e("EventRepository", "getEventDetail failed: ${e.message}", e)
+            Result.failure(e)
+        }
+    }
+
+    suspend fun getSimilarEvents(
+        eventId: String,
+        token: String? = null
+    ): Result<List<EventListItemDto>> {
+        return try {
+            val authHeader = token?.let { "Bearer $it" }
+            val response = RetrofitProvider.apiService.getSimilarEvents(eventId, authHeader)
+            if (!response.isSuccessful) {
+                val body = response.errorBody()?.string() ?: "Unknown error"
+                Log.e("EventRepository", "getSimilarEvents HTTP ${response.code()}: $body")
+                return Result.failure(Exception("${response.code()}: $body"))
+            }
+            Result.success(response.body() ?: emptyList())
+        } catch (e: Exception) {
+            Log.e("EventRepository", "getSimilarEvents failed: ${e.message}", e)
             Result.failure(e)
         }
     }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -44,10 +46,12 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.bounswe.group9.mobile.data.remote.AccessRequestResponseDto
 import com.bounswe.group9.mobile.data.remote.EventDetailDto
+import com.bounswe.group9.mobile.data.remote.EventListItemDto
 import com.bounswe.group9.mobile.data.remote.EventLimitedDto
 import com.bounswe.group9.mobile.data.remote.EquipmentDto
 import com.bounswe.group9.mobile.data.remote.InviteResponseDto
 import com.bounswe.group9.mobile.data.remote.VenueMetadataDto
+import com.bounswe.group9.mobile.ui.common.formatEventDate
 import java.text.SimpleDateFormat
 import java.util.Locale
 import java.util.TimeZone
@@ -61,6 +65,7 @@ fun EventDetailScreen(
     currentUserId: String? = null,
     onBack: () -> Unit,
     onNavigateToHost: (String) -> Unit = {},
+    onNavigateToEvent: (String) -> Unit = {},
     onNavigateToEdit: (EventDetailDto) -> Unit = {},
     onDeleteSuccess: () -> Unit = {}
 ) {
@@ -180,7 +185,8 @@ fun EventDetailScreen(
                     token = token,
                     currentUserId = currentUserId,
                     isHost = isHost,
-                    onNavigateToHost = onNavigateToHost
+                    onNavigateToHost = onNavigateToHost,
+                    onNavigateToEvent = onNavigateToEvent
                 )
                 uiState.limitedPreview != null -> LimitedPreviewContent(
                     event = uiState.limitedPreview!!,
@@ -451,7 +457,8 @@ private fun FullDetailContent(
     token: String?,
     currentUserId: String?,
     isHost: Boolean,
-    onNavigateToHost: (String) -> Unit
+    onNavigateToHost: (String) -> Unit,
+    onNavigateToEvent: (String) -> Unit = {}
 ) {
     Column(
         Modifier
@@ -635,6 +642,16 @@ private fun FullDetailContent(
                 onRetry = { viewModel.loadMoreComments() },
                 onNavigateToProfile = onNavigateToHost
             )
+
+            // Similar events
+            if (uiState.similarEvents.isNotEmpty() || uiState.similarEventsLoading) {
+                Spacer(Modifier.height(16.dp))
+                SimilarEventsSection(
+                    events = uiState.similarEvents,
+                    isLoading = uiState.similarEventsLoading,
+                    onEventClick = onNavigateToEvent
+                )
+            }
 
             Spacer(Modifier.height(32.dp))
         }
@@ -1102,6 +1119,90 @@ private fun InfoRow(label: String, value: String) {
     Row {
         Text("$label: ", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
         Text(value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun SimilarEventsSection(
+    events: List<EventListItemDto>,
+    isLoading: Boolean,
+    onEventClick: (String) -> Unit
+) {
+    SectionHeader("Similar Events")
+    if (isLoading && events.isEmpty()) {
+        Box(Modifier.fillMaxWidth().height(140.dp), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+        }
+        return
+    }
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(end = 4.dp)
+    ) {
+        items(events) { event ->
+            SimilarEventCard(event = event, onClick = { onEventClick(event.id) })
+        }
+    }
+}
+
+@Composable
+private fun SimilarEventCard(
+    event: EventListItemDto,
+    onClick: () -> Unit
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.width(180.dp).height(200.dp),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(90.dp)
+                    .background(MaterialTheme.colorScheme.tertiary.copy(alpha = 0.2f))
+            ) {
+                if (event.primary_image_url != null) {
+                    AsyncImage(
+                        model = event.primary_image_url,
+                        contentDescription = event.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+            Column(Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
+                Text(
+                    event.title,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 13.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    formatEventDate(event.start_datetime),
+                    fontSize = 11.sp,
+                    color = MaterialTheme.colorScheme.tertiary,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (event.categories.isNotEmpty()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        event.categories.first().name,
+                        fontSize = 11.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/eventdetail/EventDetailViewModel.kt
@@ -6,6 +6,7 @@ import com.bounswe.group9.mobile.data.remote.AccessRequestResponseDto
 import com.bounswe.group9.mobile.data.remote.CommentDto
 import com.bounswe.group9.mobile.data.remote.EventDetailDto
 import com.bounswe.group9.mobile.data.remote.EventLimitedDto
+import com.bounswe.group9.mobile.data.remote.EventListItemDto
 import com.bounswe.group9.mobile.data.remote.InviteResponseDto
 import com.bounswe.group9.mobile.data.repository.EventDetailError
 import com.bounswe.group9.mobile.data.repository.EventDetailResult
@@ -49,7 +50,10 @@ data class EventDetailUiState(
     val accessRequests: List<AccessRequestResponseDto> = emptyList(),
     val isLoadingInviteSection: Boolean = false,
     val isCreatingInvite: Boolean = false,
-    val inviteSectionError: String? = null
+    val inviteSectionError: String? = null,
+    // Similar events
+    val similarEvents: List<EventListItemDto> = emptyList(),
+    val similarEventsLoading: Boolean = false
 ) {
     val isLimited: Boolean get() = limitedPreview != null && fullDetail == null
     val hasData: Boolean get() = fullDetail != null || limitedPreview != null
@@ -85,6 +89,7 @@ class EventDetailViewModel(
                         loadComments(reset = true)
                         if (token != null) loadInviteSection()
                         loadHostUsername(r.detail.host_id)
+                        loadSimilarEvents(eventId)
                     }
                     is EventDetailResult.Limited -> {
                         // Age-restricted limited preview: check user age before showing
@@ -503,6 +508,23 @@ class EventDetailViewModel(
                         isHostActionLoading = false,
                         actionError = e.message
                     )
+                }
+            )
+        }
+    }
+
+    private fun loadSimilarEvents(eventId: String) {
+        _uiState.value = _uiState.value.copy(similarEventsLoading = true)
+        viewModelScope.launch {
+            repository.getSimilarEvents(eventId, currentToken).fold(
+                onSuccess = { items ->
+                    _uiState.value = _uiState.value.copy(
+                        similarEvents = items,
+                        similarEventsLoading = false
+                    )
+                },
+                onFailure = {
+                    _uiState.value = _uiState.value.copy(similarEventsLoading = false)
                 }
             )
         }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/navigation/NavGraph.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/navigation/NavGraph.kt
@@ -160,6 +160,9 @@ fun AppNavGraph(
                 onNavigateToHost = { hostId ->
                     navController.navigate(Routes.hostProfile(hostId))
                 },
+                onNavigateToEvent = { targetEventId ->
+                    navController.navigate(Routes.eventDetail(targetEventId))
+                },
                 onNavigateToEdit = { event ->
                     navController.navigate(Routes.editEvent(event.id))
                 },


### PR DESCRIPTION
Closes #281
Closes #283

## Summary

Implements the "Similar Events" feature end-to-end — backend endpoint + mobile UI — in a single branch as the two sides are tightly coupled.

---

## Backend

### New endpoint
`GET /events/{event_id}/similar` — optional auth (Bearer token optional). Returns up to 5 ranked `EventListItemResponse` objects.

### Similarity scoring
All `published`/`updated`, future (`end_datetime ≥ now`), `public` events are fetched as candidates (excluding the source event itself). Each candidate is scored:

| Signal | Weight |
|--------|--------|
| Shared category (per overlap) | +3 |
| Same host | +2 |
| Primary location within 50 km | +1 |

Candidates are sorted by descending score, then `start_datetime` (soonest first) as a tiebreaker. The top 5 are enriched and returned.

### Files changed
- `app/repositories/event.py` — added `get_similar_candidates()`: queries the DB for eligible candidate events
- `app/services/event.py` — added `get_similar_events()`: scores candidates using `_haversine_km`, batch-enriches top 5 with locations, images, and bookmark counts; supports optional auth (guests receive `is_bookmarked: null`)
- `app/routers/events.py` — wired `GET /{event_id}/similar` route using the existing `_optional_user_id` dependency

### Tests
- `tests/test_similar_events_unit.py` — 8 new unit tests (all DB calls mocked):
  - 404 when source event does not exist
  - Empty list when no candidates qualify
  - Category overlap drives ranking
  - Host match contributes to score
  - Proximity bonus applied for events ≤50 km away
  - Result capped at 5
  - Guest receives `is_bookmarked: null`
  - Authenticated user receives correct bookmark state

---

## Mobile

### New API call
`GET /events/{event_id}/similar` added to `ApiService` (optional auth header) returning `List<EventListItemDto>`.

### Repository
`EventRepository.getSimilarEvents()` — wraps the API call, returns `Result<List<EventListItemDto>>`, fails silently on error so it never breaks the main event detail load.

### ViewModel
`EventDetailUiState` gains two new fields:
- `similarEvents: List<EventListItemDto>`
- `similarEventsLoading: Boolean`

`loadSimilarEvents()` is triggered automatically after a full event detail loads successfully.

### UI — Event Detail Screen
- **`SimilarEventsSection`**: horizontal `LazyRow` placed at the very bottom of the event detail page, below the Comments section. Hidden entirely when the list is empty.
- **`SimilarEventCard`**: fixed-size card (`180×200dp`) showing event image (cropped), title (max 2 lines, ellipsized), date, and primary category. Long titles and images never expand the card.
- Tapping a card navigates to that event's detail page via the new `onNavigateToEvent` callback wired through `NavGraph`.

### Files changed
- `data/remote/ApiService.kt` — new `getSimilarEvents` endpoint declaration
- `data/repository/EventRepository.kt` — new `getSimilarEvents` repository method
- `ui/eventdetail/EventDetailViewModel.kt` — `similarEvents`/`similarEventsLoading` state + `loadSimilarEvents()`
- `ui/eventdetail/EventDetailScreen.kt` — `SimilarEventsSection`, `SimilarEventCard`, `onNavigateToEvent` parameter
- `ui/navigation/NavGraph.kt` — passes `onNavigateToEvent` lambda to `EventDetailScreen`

---

## Test plan
- [ ] Open any published public event detail → "Similar Events" section appears at the bottom (below comments) with horizontally scrollable cards
- [ ] Cards have fixed size regardless of title length or missing image
- [ ] Tapping a card navigates to that event's detail page; back button returns correctly
- [ ] Event with no similar candidates → section is completely hidden (no empty header)
- [ ] Guest (unauthenticated) → section renders without errors
- [ ] `GET /events/{event_id}/similar` returns 404 for a non-existent event ID
- [ ] All 8 unit tests pass: `pytest tests/test_similar_events_unit.py`
