### PR TITLE
feat(web): clickable profile buttons across event pages (#240)

### DIFF
--- a/frontend/src/app/event/[id]/attendees/page.tsx
+++ b/frontend/src/app/event/[id]/attendees/page.tsx
@@ -15,6 +15,7 @@ import {
 
 import { useAuth } from "@/hooks/use-auth";
 import { Navbar } from "@/components/layout/navbar";
+import { getProfileHref } from "@/lib/profile-route";
 import {
   fetchEventDetail,
   fetchAccessRequests,
@@ -169,9 +170,11 @@ export default function ManageAttendeesPage() {
                 </p>
                 <div className="space-y-2">
                   {event.attendees.map((attendee) => (
-                    <div
+                    <Link
                       key={attendee.id}
-                      className="flex items-center gap-3 rounded-lg bg-brand-bg px-3 py-2.5"
+                      href={getProfileHref(attendee.id, user?.id ?? null)}
+                      aria-label={`View ${attendee.username}'s profile`}
+                      className="flex items-center gap-3 rounded-lg bg-brand-bg px-3 py-2.5 transition-colors hover:bg-brand-mid-alpha focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-1"
                     >
                       <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-brand-mid text-white text-[12px] font-bold">
                         {attendee.username.slice(0, 2).toUpperCase()}
@@ -180,7 +183,7 @@ export default function ManageAttendeesPage() {
                         {attendee.username}
                       </span>
                       <Check className="size-3.5 text-green-600 ml-auto" />
-                    </div>
+                    </Link>
                   ))}
                 </div>
               </div>
@@ -218,14 +221,18 @@ export default function ManageAttendeesPage() {
                         key={req.id}
                         className="flex items-center justify-between gap-3 rounded-lg bg-brand-bg px-3 py-2.5"
                       >
-                        <div className="flex items-center gap-3 min-w-0">
+                        <Link
+                          href={getProfileHref(req.user_id, user?.id ?? null)}
+                          aria-label={`View ${req.username}'s profile`}
+                          className="flex items-center gap-3 min-w-0 transition-colors rounded-md hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-1"
+                        >
                           <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-brand-surface text-brand-dark text-[12px] font-bold">
                             {req.username.slice(0, 2).toUpperCase()}
                           </div>
-                          <span className="text-[14px] font-bold text-brand-dark truncate">
+                          <span className="text-[14px] font-bold text-brand-dark truncate hover:underline">
                             {req.username}
                           </span>
-                        </div>
+                        </Link>
                         <div className="flex gap-2 shrink-0">
                           <button
                             onClick={() => { void handleAction(req.id, "approved"); }}

--- a/frontend/src/app/event/[id]/page.tsx
+++ b/frontend/src/app/event/[id]/page.tsx
@@ -38,6 +38,7 @@ import { ConfirmDialog } from "@/components/event/confirm-dialog";
 import { AttendeeAvatarStack } from "@/components/event/attendee-avatar-stack";
 import { LocationMapModal } from "@/components/event/location-map-modal";
 import { cn } from "@/lib/utils";
+import { getProfileHref } from "@/lib/profile-route";
 import {
   clearAccessRequestPending,
   isAccessRequestPending,
@@ -702,7 +703,7 @@ function FullView({
                 <>
                   Created by{" "}
                   <Link
-                    href={`/profile/${event.host_id}`}
+                    href={getProfileHref(event.host_id, currentUserId)}
                     className="text-brand-dark font-bold hover:underline"
                   >
                     {host.username}
@@ -1055,9 +1056,12 @@ function FullView({
                       key={req.id}
                       className="flex items-center justify-between gap-2 rounded-lg bg-brand-bg px-3 py-2"
                     >
-                      <span className="text-[13px] font-bold text-brand-dark truncate flex-1">
+                      <Link
+                        href={getProfileHref(req.user_id, currentUserId)}
+                        className="text-[13px] font-bold text-brand-dark truncate flex-1 hover:underline focus:outline-none focus-visible:underline"
+                      >
                         {req.username}
-                      </span>
+                      </Link>
                       <div className="flex gap-1.5">
                         <button
                           onClick={() => { void handleAccessRequestAction(req.id, "approved"); }}
@@ -1085,11 +1089,20 @@ function FullView({
           {host ? (
             <div className="bg-brand-surface rounded-xl border border-brand-mid-alpha p-5">
               <div className="flex items-center gap-3 mb-3">
-                <div className="bg-brand-mid flex size-16 shrink-0 items-center justify-center rounded-full text-[22px] font-bold text-white">
+                <Link
+                  href={getProfileHref(event.host_id, currentUserId)}
+                  aria-label={`View ${host.username}'s profile`}
+                  className="bg-brand-mid flex size-16 shrink-0 items-center justify-center rounded-full text-[22px] font-bold text-white transition-transform hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-2"
+                >
                   {host.username.slice(0, 2).toUpperCase()}
-                </div>
+                </Link>
                 <div>
-                  <p className="font-bold text-[16px] text-brand-dark">{host.username}</p>
+                  <Link
+                    href={getProfileHref(event.host_id, currentUserId)}
+                    className="font-bold text-[16px] text-brand-dark hover:underline focus:outline-none focus-visible:underline"
+                  >
+                    {host.username}
+                  </Link>
                   <p className="text-[13px] text-brand-mid">
                     {isHost ? "You are the host" : "Event Host"}
                   </p>
@@ -1108,7 +1121,7 @@ function FullView({
               </p>
               {event.host_id && (
                 <Link
-                  href={`/profile/${event.host_id}`}
+                  href={getProfileHref(event.host_id, currentUserId)}
                   className="text-[13px] font-bold text-brand-mid hover:text-brand-dark transition-colors"
                 >
                   View Profile →
@@ -1181,7 +1194,11 @@ function FullView({
               {/* Avatar stack */}
               {event.attendees && event.attendees.length > 0 && (
                 <div className="mb-3">
-                  <AttendeeAvatarStack attendees={event.attendees} maxShow={5} />
+                  <AttendeeAvatarStack
+                    attendees={event.attendees}
+                    maxShow={5}
+                    currentUserId={currentUserId}
+                  />
                 </div>
               )}
               {event.attendee_limit ? (

--- a/frontend/src/components/event/attendee-avatar-stack.tsx
+++ b/frontend/src/components/event/attendee-avatar-stack.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import Link from "next/link";
+
+import { getProfileHref } from "@/lib/profile-route";
 import { cn } from "@/lib/utils";
 
 interface Attendee {
@@ -11,6 +14,7 @@ interface AttendeeAvatarStackProps {
   attendees?: Attendee[];
   maxShow?: number;
   className?: string;
+  currentUserId?: string | null;
 }
 
 function getAvatarColor(userId: string): string {
@@ -28,6 +32,7 @@ export function AttendeeAvatarStack({
   attendees = [],
   maxShow = 5,
   className,
+  currentUserId = null,
 }: AttendeeAvatarStackProps) {
   if (attendees.length === 0) {
     return null;
@@ -39,17 +44,19 @@ export function AttendeeAvatarStack({
   return (
     <div className={cn("flex items-center", className)}>
       {shown.map((attendee, index) => (
-        <div
+        <Link
           key={attendee.id}
-          className={cn(
-            "flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white border-2 border-white",
-            getAvatarColor(attendee.id),
-            index > 0 && "-ml-2"
-          )}
+          href={getProfileHref(attendee.id, currentUserId)}
+          aria-label={`View ${attendee.username}'s profile`}
           title={attendee.username}
+          className={cn(
+            "flex size-9 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white border-2 border-white transition-transform hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-1",
+            getAvatarColor(attendee.id),
+            index > 0 && "-ml-2",
+          )}
         >
           {initials(attendee.username)}
-        </div>
+        </Link>
       ))}
       {remaining > 0 && (
         <div className="ml-2 text-sm font-bold text-brand-mid">

--- a/frontend/src/components/event/comment-section.tsx
+++ b/frontend/src/components/event/comment-section.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { CornerDownRight, Send, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { getProfileHref } from "@/lib/profile-route";
 import {
   fetchComments,
   postComment,
@@ -108,20 +110,25 @@ function CommentNode({
     <div className={cn("flex gap-3 py-3", depth > 0 && "ml-8 border-l-2 border-brand-mid-alpha/40 pl-4")}>
       <div className="flex-1 min-w-0">
         <div className="flex items-start gap-3">
-          <div
+          <Link
+            href={getProfileHref(comment.user.id, currentUserId)}
+            aria-label={`View ${comment.user.username}'s profile`}
             className={cn(
-              "flex shrink-0 items-center justify-center rounded-full text-xs font-bold text-white",
+              "flex shrink-0 items-center justify-center rounded-full text-xs font-bold text-white transition-transform hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-dark focus-visible:ring-offset-1",
               depth === 0 ? "size-8" : "size-6 text-[10px]",
               avatarColor(comment.user.id),
             )}
           >
             {initials(comment.user.username)}
-          </div>
+          </Link>
           <div className="flex-1 min-w-0">
             <div className="mb-1">
-              <strong className="text-sm font-bold text-brand-dark">
+              <Link
+                href={getProfileHref(comment.user.id, currentUserId)}
+                className="text-sm font-bold text-brand-dark hover:underline focus:outline-none focus-visible:underline"
+              >
                 {comment.user.username}
-              </strong>
+              </Link>
               <span className="text-[12px] text-brand-mid ml-2">· {timeAgo(comment.created_at)}</span>
               {currentUserId === comment.user.id && (
                 <button

--- a/frontend/src/lib/profile-route.ts
+++ b/frontend/src/lib/profile-route.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns the profile page href for the given user. When the target is the
+ * authenticated user themselves, route to the personal /profile/me page so
+ * they land on the editable view instead of the public host profile.
+ */
+export function getProfileHref(userId: string, currentUserId: string | null): string {
+  if (currentUserId && userId === currentUserId) {
+    return "/profile/me";
+  }
+  return `/profile/${userId}`;
+}

--- a/frontend/tests/profile-route.test.ts
+++ b/frontend/tests/profile-route.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getProfileHref } from "@/lib/profile-route";
+
+describe("getProfileHref", () => {
+  it("returns the public profile path for another user", () => {
+    expect(getProfileHref("user-a", "user-b")).toBe("/profile/user-a");
+  });
+
+  it("returns /profile/me when target equals the current user", () => {
+    expect(getProfileHref("user-a", "user-a")).toBe("/profile/me");
+  });
+
+  it("returns the public profile path when no current user is provided", () => {
+    expect(getProfileHref("user-a", null)).toBe("/profile/user-a");
+  });
+});


### PR DESCRIPTION
Closes #240.

## Summary
- Host avatar/username, comment author avatar+name, attendee avatar stack, and host-only access request rows are now wrapped in profile links — users can navigate to anyone's profile from anywhere they appear.
- Adds a `getProfileHref(userId, currentUserId)` helper so self-clicks resolve to `/profile/me` instead of the public host profile.
- Surfaces covered: event detail (`/event/[id]`), Manage Attendees (`/event/[id]/attendees`), invite/access-request panels.

## Surfaces touched
- `event/[id]/page.tsx` — sidebar host card avatar+username, "Created by" link, "View Profile →", attendee stack now passes `currentUserId`, pending access request username links.
- `event/[id]/attendees/page.tsx` — going attendee rows and access-request rows are now `<Link>`s.
- `components/event/attendee-avatar-stack.tsx` — every visible avatar is a profile link with focus/hover state and a descriptive `aria-label`.
- `components/event/comment-section.tsx` — commenter avatar circle and username are both links.
- `lib/profile-route.ts` (new) — single source of truth for the self-vs-public routing rule.
- `tests/profile-route.test.ts` (new) — unit tests for the helper.

## Skipped intentionally
- Host profile reviews/raters list — the rendered review list does not exist yet; this surface is part of #236.
- Notifications inbox — backend payload embeds the username inside the message string with no structured user reference; would require a backend change first.
- Discovery EventCard — host name/avatar is not rendered on the card.

## Verification
- `npx tsc --noEmit` — clean
- `npx eslint <changed files>` — clean
- `npx vitest run` — 19/19 (16 existing + 3 new for the helper)
- Manual end-to-end in a local browser logged in as a test host:
  - Public event: created, published, second user marked Going. Manage Attendees → Going row → `/profile/{u2Id}` ✅
  - Private event: created, second user sent access request. Event detail sidebar "Pending Requests" → `/profile/{u2Id}` ✅. Manage Attendees → Access Requests row → `/profile/{u2Id}` ✅
  - Self-click: own comment avatar/username and own attendee avatar route to `/profile/me` ✅
  - Avatar circle click in the host card navigates to the host profile page ✅

## Test plan
- [ ] Open a public event detail as a non-host: host avatar circle, username, "Created by", and "View Profile →" all open the host's profile.
- [ ] Open the comments section: clicking any commenter's avatar or name opens that user's profile (own comments → `/profile/me`).
- [ ] Open Manage Attendees on a hosted event: clicking a Going row opens the attendee's profile.
- [ ] Open Manage Attendees on a hosted private event with a pending access request: clicking the request row opens the requester's profile (Approve/Reject still work).
- [ ] Open the event detail sidebar invite panel: clicking a pending request username opens the requester's profile.
- [ ] Confirm focus rings appear on tab/keyboard navigation across the avatar links.