### PR TITLE
Backend: event_recommended notifications on publish (#278)

### DIFF
--- a/backend/app/repositories/attendance.py
+++ b/backend/app/repositories/attendance.py
@@ -75,3 +75,17 @@ def has_attended_ended_event_by_host(db: Client, user_id: str, host_id: str) -> 
         .execute()
     )
     return bool(result.data)
+
+
+def find_users_going_on_events(db: Client, event_ids: list[str]) -> set[str]:
+    """Return user_ids that have status='going' on any of event_ids."""
+    if not event_ids:
+        return set()
+    result = (
+        db.table("attendances")
+        .select("user_id")
+        .in_("event_id", event_ids)
+        .eq("status", "going")
+        .execute()
+    )
+    return {row["user_id"] for row in (result.data or [])}

--- a/backend/app/repositories/attendance.py
+++ b/backend/app/repositories/attendance.py
@@ -77,15 +77,22 @@ def has_attended_ended_event_by_host(db: Client, user_id: str, host_id: str) -> 
     return bool(result.data)
 
 
+_IN_CHUNK_SIZE = 100
+
+
 def find_users_going_on_events(db: Client, event_ids: list[str]) -> set[str]:
     """Return user_ids that have status='going' on any of event_ids."""
     if not event_ids:
         return set()
-    result = (
-        db.table("attendances")
-        .select("user_id")
-        .in_("event_id", event_ids)
-        .eq("status", "going")
-        .execute()
-    )
-    return {row["user_id"] for row in (result.data or [])}
+    users: set[str] = set()
+    for i in range(0, len(event_ids), _IN_CHUNK_SIZE):
+        chunk = event_ids[i:i + _IN_CHUNK_SIZE]
+        result = (
+            db.table("attendances")
+            .select("user_id")
+            .in_("event_id", chunk)
+            .eq("status", "going")
+            .execute()
+        )
+        users.update(row["user_id"] for row in (result.data or []))
+    return users

--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -106,3 +106,23 @@ def insert_notifications_bulk(db: Client, notifications: list[dict]) -> list[dic
         return []
     result = db.table("notifications").insert(notifications).execute()
     return result.data or []
+
+
+def count_by_type_for_users_since(
+    db: Client, user_ids: list[str], notification_type: str, cutoff_iso: str,
+) -> dict[str, int]:
+    """Return {user_id: count} of notifications of given type sent to each user since cutoff."""
+    if not user_ids:
+        return {}
+    result = (
+        db.table("notifications")
+        .select("user_id")
+        .in_("user_id", user_ids)
+        .eq("type", notification_type)
+        .gte("created_at", cutoff_iso)
+        .execute()
+    )
+    counts: dict[str, int] = {uid: 0 for uid in user_ids}
+    for row in (result.data or []):
+        counts[row["user_id"]] = counts.get(row["user_id"], 0) + 1
+    return counts

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -712,6 +712,16 @@ def change_event_status(
 
     event_repo.update_event_status(db, event_id, new_status)
 
+    # Emit recommendation notifications when an event becomes published
+    if current == "draft" and new_status == "published":
+        try:
+            from app.services.recommendation_emitter import emit_event_recommendations
+            emit_event_recommendations(db, event_id, user_id)
+        except Exception:
+            # Recommendations are best-effort: never fail the publish on emitter error
+            import logging
+            logging.getLogger(__name__).exception("emit_event_recommendations failed")
+
     # Emit notification on cancellation
     if new_status == "cancelled":
         from app.services.notification_emitter import emit_event_notification

--- a/backend/app/services/recommendation_emitter.py
+++ b/backend/app/services/recommendation_emitter.py
@@ -1,0 +1,180 @@
+"""Event recommendation notifications.
+
+When a host publishes a public event, find users whose past attendance pattern
+(category overlap on `going` status of `ended` events) matches the new event,
+and emit `event_recommended` notifications to them.
+
+Privacy / safety guarantees:
+  - Private events never produce recommendations
+  - Cancelled / ended / draft / updated events never trigger this emitter
+  - The host of the event is never recommended their own event
+  - Users who already bookmarked or are going on the new event are skipped
+    (they will get the regular update channel instead)
+  - Per-user daily cap (default 3) prevents notification fatigue
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from supabase import Client
+
+from app.repositories import attendance as attendance_repo
+from app.repositories import event as event_repo
+from app.repositories import notification as notification_repo
+
+logger = logging.getLogger(__name__)
+
+# How many event_recommended notifications a user can receive in a 24h window.
+MAX_RECOMMENDATIONS_PER_DAY = 3
+
+# How far back we look for the user's attendance history when scoring matches.
+ATTENDANCE_LOOKBACK_DAYS = 90
+
+
+def emit_event_recommendations(db: Client, event_id: str, host_id: str) -> int:
+    """Insert event_recommended notifications for users whose history matches.
+
+    Returns the number of notifications inserted. Best-effort: callers should
+    invoke this in a try/except and never let a failure block the publish path.
+    """
+    event = event_repo.get_event_by_id(db, event_id)
+    if not event:
+        return 0
+
+    # Only public, currently-active events get recommendations
+    if event.get("visibility") != "public":
+        return 0
+    if event.get("status") not in ("published", "updated"):
+        return 0
+
+    category_ids = _get_event_category_ids(db, event_id)
+    if not category_ids:
+        return 0
+
+    candidate_ids = _find_candidates(db, category_ids, event_id, host_id)
+    if not candidate_ids:
+        return 0
+
+    candidate_ids = _drop_users_already_engaged(db, candidate_ids, event_id)
+    if not candidate_ids:
+        return 0
+
+    candidate_ids = _drop_users_over_daily_cap(db, candidate_ids)
+    if not candidate_ids:
+        return 0
+
+    message = _build_message(db, category_ids, event["title"])
+    rows = [
+        {
+            "user_id": uid,
+            "event_id": event_id,
+            "type": "event_recommended",
+            "message": message,
+            "is_read": False,
+        }
+        for uid in candidate_ids
+    ]
+
+    inserted = notification_repo.insert_notifications_bulk(db, rows)
+    return len(inserted)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _get_event_category_ids(db: Client, event_id: str) -> list[str]:
+    result = (
+        db.table("event_categories")
+        .select("category_id")
+        .eq("event_id", event_id)
+        .execute()
+    )
+    return [row["category_id"] for row in (result.data or [])]
+
+
+def _find_candidates(
+    db: Client, category_ids: list[str], new_event_id: str, host_id: str,
+) -> set[str]:
+    """Users with going attendance on ended events that share at least one category."""
+    # Step 1: events in any of these categories (exclude the new event itself)
+    cat_rows = (
+        db.table("event_categories")
+        .select("event_id")
+        .in_("category_id", category_ids)
+        .execute()
+    )
+    overlap_event_ids = {row["event_id"] for row in (cat_rows.data or [])}
+    overlap_event_ids.discard(new_event_id)
+    if not overlap_event_ids:
+        return set()
+
+    # Step 2: filter to ended events within the lookback window
+    cutoff = (datetime.now(UTC) - timedelta(days=ATTENDANCE_LOOKBACK_DAYS)).isoformat()
+    ended_rows = (
+        db.table("events")
+        .select("id")
+        .in_("id", list(overlap_event_ids))
+        .eq("status", "ended")
+        .gte("end_datetime", cutoff)
+        .execute()
+    )
+    ended_event_ids = [row["id"] for row in (ended_rows.data or [])]
+    if not ended_event_ids:
+        return set()
+
+    # Step 3: users who attended any of those ended events
+    candidates = attendance_repo.find_users_going_on_events(db, ended_event_ids)
+    candidates.discard(host_id)
+    return candidates
+
+
+def _drop_users_already_engaged(
+    db: Client, user_ids: set[str], event_id: str,
+) -> set[str]:
+    """Skip users who already bookmarked or are going on the new event."""
+    if not user_ids:
+        return user_ids
+
+    user_id_list = list(user_ids)
+    bookmark_rows = (
+        db.table("bookmarks")
+        .select("user_id")
+        .eq("event_id", event_id)
+        .in_("user_id", user_id_list)
+        .execute()
+    )
+    attendance_rows = (
+        db.table("attendances")
+        .select("user_id")
+        .eq("event_id", event_id)
+        .in_("user_id", user_id_list)
+        .execute()
+    )
+    engaged = {row["user_id"] for row in (bookmark_rows.data or [])}
+    engaged.update(row["user_id"] for row in (attendance_rows.data or []))
+    return user_ids - engaged
+
+
+def _drop_users_over_daily_cap(db: Client, user_ids: set[str]) -> set[str]:
+    """Skip users that already received MAX_RECOMMENDATIONS_PER_DAY today."""
+    if not user_ids:
+        return user_ids
+    cutoff = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
+    counts = notification_repo.count_by_type_for_users_since(
+        db, list(user_ids), "event_recommended", cutoff,
+    )
+    return {uid for uid in user_ids if counts.get(uid, 0) < MAX_RECOMMENDATIONS_PER_DAY}
+
+
+def _build_message(db: Client, category_ids: list[str], event_title: str) -> str:
+    """Use the first matching category name to build a human-readable reason."""
+    first_id = category_ids[0]
+    cat_row = (
+        db.table("categories")
+        .select("name")
+        .eq("id", first_id)
+        .limit(1)
+        .execute()
+    )
+    if cat_row.data:
+        return f"New event '{event_title}' — based on events you attended in {cat_row.data[0]['name']}"
+    return f"New event '{event_title}' might match your interests"

--- a/backend/app/services/recommendation_emitter.py
+++ b/backend/app/services/recommendation_emitter.py
@@ -30,6 +30,10 @@ MAX_RECOMMENDATIONS_PER_DAY = 3
 # How far back we look for the user's attendance history when scoring matches.
 ATTENDANCE_LOOKBACK_DAYS = 90
 
+# PostgREST encodes .in_() as a URL query param; keep chunks small enough to
+# stay well under the ~8 KB URL limit (36 chars per UUID + overhead).
+_IN_CHUNK_SIZE = 100
+
 
 def emit_event_recommendations(db: Client, event_id: str, host_id: str) -> int:
     """Insert event_recommended notifications for users whose history matches.
@@ -56,6 +60,10 @@ def emit_event_recommendations(db: Client, event_id: str, host_id: str) -> int:
         return 0
 
     candidate_ids = _drop_users_already_engaged(db, candidate_ids, event_id)
+    if not candidate_ids:
+        return 0
+
+    candidate_ids = _drop_users_already_notified(db, candidate_ids, event_id)
     if not candidate_ids:
         return 0
 
@@ -107,17 +115,22 @@ def _find_candidates(
     if not overlap_event_ids:
         return set()
 
-    # Step 2: filter to ended events within the lookback window
+    # Step 2: filter to ended events within the lookback window.
+    # Chunk to avoid PostgREST URL-length limits on large .in_() lists.
     cutoff = (datetime.now(UTC) - timedelta(days=ATTENDANCE_LOOKBACK_DAYS)).isoformat()
-    ended_rows = (
-        db.table("events")
-        .select("id")
-        .in_("id", list(overlap_event_ids))
-        .eq("status", "ended")
-        .gte("end_datetime", cutoff)
-        .execute()
-    )
-    ended_event_ids = [row["id"] for row in (ended_rows.data or [])]
+    overlap_list = list(overlap_event_ids)
+    ended_event_ids: list[str] = []
+    for i in range(0, len(overlap_list), _IN_CHUNK_SIZE):
+        chunk = overlap_list[i:i + _IN_CHUNK_SIZE]
+        rows = (
+            db.table("events")
+            .select("id")
+            .in_("id", chunk)
+            .eq("status", "ended")
+            .gte("end_datetime", cutoff)
+            .execute()
+        )
+        ended_event_ids.extend(row["id"] for row in (rows.data or []))
     if not ended_event_ids:
         return set()
 
@@ -163,6 +176,24 @@ def _drop_users_over_daily_cap(db: Client, user_ids: set[str]) -> set[str]:
         db, list(user_ids), "event_recommended", cutoff,
     )
     return {uid for uid in user_ids if counts.get(uid, 0) < MAX_RECOMMENDATIONS_PER_DAY}
+
+
+def _drop_users_already_notified(
+    db: Client, user_ids: set[str], event_id: str,
+) -> set[str]:
+    """Skip users who already have an event_recommended notification for this event."""
+    if not user_ids:
+        return user_ids
+    result = (
+        db.table("notifications")
+        .select("user_id")
+        .eq("event_id", event_id)
+        .eq("type", "event_recommended")
+        .in_("user_id", list(user_ids))
+        .execute()
+    )
+    already_notified = {row["user_id"] for row in (result.data or [])}
+    return user_ids - already_notified
 
 
 def _build_message(db: Client, category_ids: list[str], event_title: str) -> str:

--- a/backend/sql/017_add_event_recommended_notification.sql
+++ b/backend/sql/017_add_event_recommended_notification.sql
@@ -1,0 +1,22 @@
+-- Add 'event_recommended' to the notifications.type CHECK constraint.
+--
+-- Source for the existing types:
+--   002_create_core_tables.sql defines event_updated / event_cancelled / event_deleted.
+--   The access-request feature added event_request / access_approved / access_rejected
+--   to the live DB through later DDL. This migration is the consolidated re-statement
+--   of the constraint with the new type included.
+
+ALTER TABLE public.notifications
+    DROP CONSTRAINT IF EXISTS notifications_type_check;
+
+ALTER TABLE public.notifications
+    ADD CONSTRAINT notifications_type_check
+    CHECK (type IN (
+        'event_updated',
+        'event_cancelled',
+        'event_deleted',
+        'access_request',
+        'access_approved',
+        'access_rejected',
+        'event_recommended'
+    ));

--- a/backend/tests/test_recommendation_emitter.py
+++ b/backend/tests/test_recommendation_emitter.py
@@ -257,6 +257,25 @@ class TestRecommendationEmitter:
 
         assert _get_recs(listener["id"]) == []
 
+    def test_duplicate_notification_not_emitted(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        _cleanup_notifications(listener["id"])
+        new_event = _create_published_event(host["id"], [cat_a])
+
+        # First run should produce exactly 1 notification
+        recs_after_first = _get_recs(listener["id"])
+        assert len(recs_after_first) == 1
+
+        # Second run (emitter called again for same event) must not produce a duplicate
+        emit_event_recommendations(db, new_event, host["id"])
+        assert len(_get_recs(listener["id"])) == 1
+
     def test_attendance_on_non_ended_event_does_not_match(self):
         cat_a, _ = _two_category_ids()
         host = _create_user()

--- a/backend/tests/test_recommendation_emitter.py
+++ b/backend/tests/test_recommendation_emitter.py
@@ -1,0 +1,274 @@
+"""Tests for the event_recommended notification emitter."""
+
+import io
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from app.database import get_supabase
+from app.main import app
+from app.services.auth import create_access_token
+from app.services.recommendation_emitter import (
+    MAX_RECOMMENDATIONS_PER_DAY,
+    emit_event_recommendations,
+)
+from tests_support import build_test_identity
+
+client = TestClient(app)
+db = get_supabase()
+
+MOCK_STORAGE_URL = "https://example.com/storage/v1/object/public/event-images/test.jpg"
+
+
+# --- Helpers --------------------------------------------------------------
+
+def _auth_header(user_id: str) -> dict:
+    token = create_access_token(user_id, "test@test.com")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_user(prefix: str = "rectest") -> dict:
+    username, email = build_test_identity(prefix)
+    resp = client.post("/auth/register", json={
+        "username": username,
+        "email": email,
+        "password": "testpass123",
+        "date_of_birth": "2000-01-15",
+    })
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["user"]
+
+
+def _two_category_ids() -> tuple[str, str]:
+    result = db.table("categories").select("id").eq("is_predefined", True).limit(2).execute()
+    rows = result.data or []
+    assert len(rows) >= 2, "need at least two predefined categories for tests"
+    return rows[0]["id"], rows[1]["id"]
+
+
+def _make_image_bytes() -> bytes:
+    img = PILImage.new("RGB", (100, 100), color="green")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+@patch("app.repositories.image.upload_to_storage", return_value=MOCK_STORAGE_URL)
+def _create_published_event(
+    host_id: str, category_ids: list[str], mock_upload, *, visibility: str = "public",  # noqa: ARG001
+) -> str:
+    start = datetime.now(UTC) + timedelta(days=5)
+    end = start + timedelta(hours=2)
+    body = {
+        "title": f"New Event {uuid.uuid4().hex[:6]}",
+        "description": "Test event",
+        "start_datetime": start.isoformat(),
+        "end_datetime": end.isoformat(),
+        "visibility": visibility,
+        "is_age_restricted": False,
+        "status": "draft",
+        "category_ids": category_ids,
+        "locations": [{"name": "Venue", "latitude": 41.0, "longitude": 29.0, "is_primary": True, "order_index": 0}],
+    }
+    create = client.post("/events", json=body, headers=_auth_header(host_id))
+    assert create.status_code == 201, create.json()
+    event_id = create.json()["id"]
+    img = client.post(
+        f"/events/{event_id}/images",
+        files={"file": ("img.jpg", _make_image_bytes(), "image/jpeg")},
+        headers=_auth_header(host_id),
+    )
+    assert img.status_code == 201
+    pub = client.patch(
+        f"/events/{event_id}/status",
+        json={"status": "published"},
+        headers=_auth_header(host_id),
+    )
+    assert pub.status_code == 200, pub.json()
+    return event_id
+
+
+def _insert_ended_event(host_id: str, category_id: str, *, days_ago: int = 7) -> str:
+    """Insert an ended public event directly via DB (bypasses publish validators)."""
+    end_dt = datetime.now(UTC) - timedelta(days=days_ago)
+    start_dt = end_dt - timedelta(hours=2)
+    event = db.table("events").insert({
+        "host_id": host_id,
+        "title": f"Past Event {uuid.uuid4().hex[:6]}",
+        "description": "Historical event",
+        "start_datetime": start_dt.isoformat(),
+        "end_datetime": end_dt.isoformat(),
+        "visibility": "public",
+        "is_age_restricted": False,
+        "status": "ended",
+    }).execute().data[0]
+    event_id = event["id"]
+    db.table("event_locations").insert({
+        "event_id": event_id,
+        "name": "Past venue",
+        "latitude": 41.0,
+        "longitude": 29.0,
+        "is_primary": True,
+        "order_index": 0,
+    }).execute()
+    db.table("event_categories").insert({
+        "event_id": event_id,
+        "category_id": category_id,
+    }).execute()
+    return event_id
+
+
+def _add_attendance(user_id: str, event_id: str, att_status: str = "going") -> None:
+    db.table("attendances").insert({
+        "user_id": user_id,
+        "event_id": event_id,
+        "status": att_status,
+    }).execute()
+
+
+def _add_bookmark(user_id: str, event_id: str) -> None:
+    db.table("bookmarks").insert({"user_id": user_id, "event_id": event_id}).execute()
+
+
+def _get_recs(user_id: str) -> list[dict]:
+    res = db.table("notifications").select(
+        "id,event_id,type,message,is_read,created_at",
+    ).eq("user_id", user_id).eq("type", "event_recommended").execute()
+    return res.data or []
+
+
+def _cleanup_notifications(user_id: str) -> None:
+    db.table("notifications").delete().eq("user_id", user_id).execute()
+
+
+# --- Tests ----------------------------------------------------------------
+
+class TestRecommendationEmitter:
+
+    def test_match_emits_notification(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        # Listener attended an ended event in cat_a
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        # Host publishes a new event in cat_a → listener should be recommended
+        _cleanup_notifications(listener["id"])
+        new_event = _create_published_event(host["id"], [cat_a])
+
+        recs = _get_recs(listener["id"])
+        assert len(recs) == 1
+        assert recs[0]["event_id"] == new_event
+
+    def test_no_history_no_notification(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        bystander = _create_user()
+
+        _cleanup_notifications(bystander["id"])
+        _create_published_event(host["id"], [cat_a])
+
+        assert _get_recs(bystander["id"]) == []
+
+    def test_host_excluded_from_own_event(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+
+        # Host attended a previous event in cat_a
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(host["id"], past, "going")
+
+        _cleanup_notifications(host["id"])
+        _create_published_event(host["id"], [cat_a])
+
+        assert _get_recs(host["id"]) == []
+
+    def test_private_event_no_recommendations(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        _cleanup_notifications(listener["id"])
+        _create_published_event(host["id"], [cat_a], visibility="private")
+
+        assert _get_recs(listener["id"]) == []
+
+    def test_already_bookmarked_skipped(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        # Pre-bookmark the new event then call emitter directly
+        new_id = _create_published_event(host["id"], [cat_a])
+        # The publish above already fired the emitter once; reset and re-run
+        _cleanup_notifications(listener["id"])
+        _add_bookmark(listener["id"], new_id)
+
+        emit_event_recommendations(db, new_id, host["id"])
+        assert _get_recs(listener["id"]) == []
+
+    def test_daily_cap(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        _cleanup_notifications(listener["id"])
+        # Pre-fill cap-1 recommendations (older events still trigger emitter)
+        for _ in range(MAX_RECOMMENDATIONS_PER_DAY):
+            db.table("notifications").insert({
+                "user_id": listener["id"],
+                "event_id": None,
+                "type": "event_recommended",
+                "message": "preexisting",
+                "is_read": False,
+            }).execute()
+
+        # Now publish a fresh event — listener already at cap, should not gain a 4th
+        _create_published_event(host["id"], [cat_a])
+
+        recs = _get_recs(listener["id"])
+        assert len(recs) == MAX_RECOMMENDATIONS_PER_DAY
+
+    def test_no_category_overlap(self):
+        cat_a, cat_b = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        past = _insert_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        _cleanup_notifications(listener["id"])
+        # New event uses cat_b, listener attended cat_a → no match
+        _create_published_event(host["id"], [cat_b])
+
+        assert _get_recs(listener["id"]) == []
+
+    def test_attendance_on_non_ended_event_does_not_match(self):
+        cat_a, _ = _two_category_ids()
+        host = _create_user()
+        listener = _create_user()
+
+        # Make a published (not yet ended) event in cat_a, listener is going
+        past = _create_published_event(host["id"], [cat_a])
+        _add_attendance(listener["id"], past, "going")
+
+        _cleanup_notifications(listener["id"])
+        # Publish another event in cat_a — listener has only "going" on a still-active event,
+        # not an ended one, so no recommendation should fire
+        _create_published_event(host["id"], [cat_a])
+
+        assert _get_recs(listener["id"]) == []


### PR DESCRIPTION
Backend half of #275 (parent issue).

When a host promotes a draft event to **published**, the backend now finds users whose past attendance pattern matches the new event's categories, and emits an `event_recommended` notification to them.

## Behaviour

- Triggered only on `draft → published` transitions for **public** events
- Match: user has a `going` attendance on a recently `ended` event that shares at least one category with the new event (90-day lookback)
- Excluded: the host themselves, users already bookmarked or going on the new event, users at the daily cap
- Daily cap: max 3 `event_recommended` notifications per user per 24h
- Best-effort: the emitter is wrapped in try/except so a failure never blocks the publish

## Required SQL migration

Run `backend/sql/017_add_event_recommended_notification.sql` in Supabase before deploy. It only extends the `notifications.type` CHECK constraint to include the new value.

## Files changed

| File | Purpose |
|---|---|
| `backend/sql/017_add_event_recommended_notification.sql` | Migration extending CHECK |
| `backend/app/services/recommendation_emitter.py` | New service module |
| `backend/app/services/event.py` | Hook in `change_event_status` |
| `backend/app/repositories/attendance.py` | `find_users_going_on_events` |
| `backend/app/repositories/notification.py` | `count_by_type_for_users_since` (for the daily cap) |
| `backend/tests/test_recommendation_emitter.py` | 8 scenarios |

## Test scenarios covered

- Category match → notification emitted
- No attendance history → no notification
- Host of the new event excluded
- Private event → no recommendations
- Candidate already bookmarked → skipped
- Daily cap (3/24h) honored
- No category overlap → no notification
- Attendance on a still-active event (not ended) → no notification

## Out of scope

Web and Mobile UI rendering of `event_recommended` notifications are separate tasks tracked in #275.

Closes #278