### PR TITLE
feat: suggested-filter-discovery-backend

### DIFF
--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -229,3 +229,7 @@ class EventListResponse(AppBaseModel):
     page: int
     page_size: int
     total_pages: int
+    # True when ?suggested=true was requested but the user has no past attendance
+    # history to bias the listing on. UI can render a "Attend events to get
+    # personalised suggestions" hint. Always False when ?suggested wasn't set.
+    suggested_fallback: bool = False

--- a/backend/app/repositories/attendance.py
+++ b/backend/app/repositories/attendance.py
@@ -117,11 +117,15 @@ def get_attended_ended_event_categories(db: Client, user_id: str) -> set[str]:
     if not event_ids:
         return set()
 
-    # Step 2: collect category_ids for those events
-    cat_rows = (
-        db.table("event_categories")
-        .select("category_id")
-        .in_("event_id", event_ids)
-        .execute()
-    )
-    return {row["category_id"] for row in (cat_rows.data or [])}
+    # Step 2: collect category_ids for those events — chunk to avoid URL limits.
+    categories: set[str] = set()
+    for i in range(0, len(event_ids), _IN_CHUNK_SIZE):
+        chunk = event_ids[i:i + _IN_CHUNK_SIZE]
+        cat_rows = (
+            db.table("event_categories")
+            .select("category_id")
+            .in_("event_id", chunk)
+            .execute()
+        )
+        categories.update(row["category_id"] for row in (cat_rows.data or []))
+    return categories

--- a/backend/app/repositories/attendance.py
+++ b/backend/app/repositories/attendance.py
@@ -96,3 +96,32 @@ def find_users_going_on_events(db: Client, event_ids: list[str]) -> set[str]:
         )
         users.update(row["user_id"] for row in (result.data or []))
     return users
+
+
+def get_attended_ended_event_categories(db: Client, user_id: str) -> set[str]:
+    """Return the set of category_ids for events the user attended (status='going')
+    on events whose status='ended'. Used to bias the Discovery listing.
+
+    Returns empty set if the user has no qualifying attendance history.
+    """
+    # Step 1: ended events the user was 'going' to
+    att_rows = (
+        db.table("attendances")
+        .select("event_id, events!inner(status)")
+        .eq("user_id", user_id)
+        .eq("status", "going")
+        .eq("events.status", "ended")
+        .execute()
+    )
+    event_ids = [row["event_id"] for row in (att_rows.data or [])]
+    if not event_ids:
+        return set()
+
+    # Step 2: collect category_ids for those events
+    cat_rows = (
+        db.table("event_categories")
+        .select("category_id")
+        .in_("event_id", event_ids)
+        .execute()
+    )
+    return {row["category_id"] for row in (cat_rows.data or [])}

--- a/backend/app/repositories/event.py
+++ b/backend/app/repositories/event.py
@@ -303,6 +303,7 @@ def list_events(
     radius_km: float | None = None,
     accessibility: dict[str, bool | None] | None = None,
     sort: str = "start_time",
+    suggested_category_ids: set[str] | None = None,
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[dict], int]:
@@ -327,6 +328,18 @@ def list_events(
             .execute()
         )
         ids = {row["event_id"] for row in (cat_result.data or [])}
+        if not ids:
+            return [], 0
+        whitelists.append(ids)
+
+    if suggested_category_ids:
+        sug_result = (
+            db.table("event_categories")
+            .select("event_id")
+            .in_("category_id", list(suggested_category_ids))
+            .execute()
+        )
+        ids = {row["event_id"] for row in (sug_result.data or [])}
         if not ids:
             return [], 0
         whitelists.append(ids)

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -134,6 +134,15 @@ def list_events_endpoint(
             "custom window, accessibility, or location — to keep the in-memory candidate set bounded."
         ),
     ),
+    suggested: bool = Query(
+        default=False,
+        description=(
+            "Bias the listing toward categories the authenticated user attended on past "
+            "ended events. Silently ignored for guests. When the user has no attendance "
+            "history, the response sets suggested_fallback=true and returns the default "
+            "listing (so the UI can render an empty-history hint)."
+        ),
+    ),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     user_id: str | None = Depends(_optional_user_id),
@@ -186,6 +195,7 @@ def list_events_endpoint(
             "quiet_friendly": quiet_friendly,
         },
         sort=sort,
+        suggested=suggested,
         page=page,
         page_size=page_size,
     )

--- a/backend/app/services/event.py
+++ b/backend/app/services/event.py
@@ -789,6 +789,7 @@ def list_events(
     use_default_area: bool = False,
     accessibility: dict[str, bool | None] | None = None,
     sort: str | None = None,
+    suggested: bool = False,
     page: int = 1,
     page_size: int = 20,
 ) -> EventListResponse:
@@ -850,6 +851,19 @@ def list_events(
 
     effective_radius_km = radius_km if radius_km is not None else (50.0 if has_location else None)
 
+    # Resolve "Suggested for you" — only meaningful for authenticated users.
+    suggested_category_ids: set[str] | None = None
+    suggested_fallback = False
+    if suggested and user_id:
+        suggested_category_ids = attendance_repo.get_attended_ended_event_categories(
+            db, user_id,
+        )
+        if not suggested_category_ids:
+            # User has no attendance history yet — fall back to default listing
+            # but signal the empty-history hint to the UI.
+            suggested_category_ids = None
+            suggested_fallback = True
+
     events, total = event_repo.list_events(
         db,
         search=search,
@@ -862,13 +876,17 @@ def list_events(
         radius_km=effective_radius_km,
         accessibility=accessibility or {},
         sort=sort,
+        suggested_category_ids=suggested_category_ids,
         page=page,
         page_size=page_size,
     )
 
     total_pages = (total + page_size - 1) // page_size if total > 0 else 0
     if not events:
-        return EventListResponse(items=[], total=total, page=page, page_size=page_size, total_pages=total_pages)
+        return EventListResponse(
+            items=[], total=total, page=page, page_size=page_size,
+            total_pages=total_pages, suggested_fallback=suggested_fallback,
+        )
 
     # For sort in {distance, category} the repo returned the full filtered set;
     # rank in Python and slice to the requested page.
@@ -898,7 +916,10 @@ def list_events(
         offset = (page - 1) * page_size
         events = events[offset:offset + page_size]
         if not events:
-            return EventListResponse(items=[], total=total, page=page, page_size=page_size, total_pages=total_pages)
+            return EventListResponse(
+                items=[], total=total, page=page, page_size=page_size,
+                total_pages=total_pages, suggested_fallback=suggested_fallback,
+            )
 
     event_ids = [e["id"] for e in events]
     locations_by_event = event_repo.get_primary_locations_for_events(db, event_ids)
@@ -959,7 +980,10 @@ def list_events(
             primary_image_url=images_by_event.get(event["id"]),
         ))
 
-    return EventListResponse(items=items, total=total, page=page, page_size=page_size, total_pages=total_pages)
+    return EventListResponse(
+        items=items, total=total, page=page, page_size=page_size,
+        total_pages=total_pages, suggested_fallback=suggested_fallback,
+    )
 
 
 def list_events_geojson(

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -936,3 +936,197 @@ class TestListEventsCategorySort:
         _cleanup_event(ev_first["id"])
         _cleanup_event(ev_second["id"])
         _cleanup_user(user["id"])
+
+
+# --- Suggested-for-you filter helpers ---
+
+def _make_ended_event(host_id: str, category_id: str, *, days_ago: int = 7) -> str:
+    """Insert an ended public event directly into the DB (bypasses publish validators)
+    so we can seed a user's attendance history.
+    """
+    end_dt = datetime.now(UTC) - timedelta(days=days_ago)
+    start_dt = end_dt - timedelta(hours=2)
+    event = db.table("events").insert({
+        "host_id": host_id,
+        "title": f"Past event {uuid.uuid4().hex[:6]}",
+        "description": "Historical event for tests",
+        "start_datetime": start_dt.isoformat(),
+        "end_datetime": end_dt.isoformat(),
+        "visibility": "public",
+        "is_age_restricted": False,
+        "status": "ended",
+    }).execute().data[0]
+    eid = event["id"]
+    db.table("event_locations").insert({
+        "event_id": eid,
+        "name": "Past venue",
+        "latitude": 41.0,
+        "longitude": 29.0,
+        "is_primary": True,
+        "order_index": 0,
+    }).execute()
+    db.table("event_categories").insert({
+        "event_id": eid,
+        "category_id": category_id,
+    }).execute()
+    return eid
+
+
+def _add_attendance(user_id: str, event_id: str, status: str = "going") -> None:
+    db.table("attendances").insert({
+        "user_id": user_id,
+        "event_id": event_id,
+        "status": status,
+    }).execute()
+
+
+class TestSuggestedFilter:
+
+    def test_match_returns_only_user_categories(self):
+        cat_a, cat_b = _get_category_ids(2)
+        host = _create_test_user("hostA")
+        listener = _create_test_user("listA")
+
+        # Listener attended an ended event in cat_a
+        past = _make_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        # Two upcoming events: one in cat_a (matches), one in cat_b (does not)
+        ev_match = _create_published_event(host["id"], [cat_a], title="Jazz Night A")
+        ev_other = _create_published_event(host["id"], [cat_b], title="Sports B")
+
+        resp = client.get("/events?suggested=true", headers=_auth_header(listener["id"]))
+        assert resp.status_code == 200
+        body = resp.json()
+        ids = {item["id"] for item in body["items"]}
+        assert ev_match["id"] in ids
+        assert ev_other["id"] not in ids
+        assert body["suggested_fallback"] is False
+
+        _cleanup_event(ev_match["id"])
+        _cleanup_event(ev_other["id"])
+        _cleanup_event(past)
+        db.table("attendances").delete().eq("user_id", listener["id"]).execute()
+        _cleanup_user(listener["id"])
+        _cleanup_user(host["id"])
+
+    def test_no_history_returns_default_with_fallback_flag(self):
+        user = _create_test_user("nohist")
+        host = _create_test_user("nohistHost")
+
+        ev = _create_published_event(host["id"], _get_category_ids(1), title="Solo")
+
+        resp = client.get("/events?suggested=true", headers=_auth_header(user["id"]))
+        assert resp.status_code == 200
+        body = resp.json()
+        # No history → falls back to default listing, ev should be visible
+        ids = {item["id"] for item in body["items"]}
+        assert ev["id"] in ids
+        assert body["suggested_fallback"] is True
+
+        _cleanup_event(ev["id"])
+        _cleanup_user(user["id"])
+        _cleanup_user(host["id"])
+
+    def test_guest_suggested_silently_ignored(self):
+        host = _create_test_user("guestHost")
+        ev = _create_published_event(host["id"], _get_category_ids(1), title="Public")
+
+        # No auth header
+        resp = client.get("/events?suggested=true")
+        assert resp.status_code == 200
+        body = resp.json()
+        ids = {item["id"] for item in body["items"]}
+        assert ev["id"] in ids
+        assert body["suggested_fallback"] is False
+
+        _cleanup_event(ev["id"])
+        _cleanup_user(host["id"])
+
+    def test_intersects_with_explicit_category_filter(self):
+        cat_a, cat_b = _get_category_ids(2)
+        host = _create_test_user("intHost")
+        listener = _create_test_user("intList")
+
+        past = _make_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        ev_a = _create_published_event(host["id"], [cat_a], title="Match")
+        ev_b = _create_published_event(host["id"], [cat_b], title="Mismatch")
+
+        # suggested=true narrows to user's categories (cat_a),
+        # category_id=cat_b further narrows → no overlap → empty result
+        resp = client.get(
+            f"/events?suggested=true&category_id={cat_b}",
+            headers=_auth_header(listener["id"]),
+        )
+        assert resp.status_code == 200
+        ids = {item["id"] for item in resp.json()["items"]}
+        assert ev_a["id"] not in ids
+        assert ev_b["id"] not in ids
+
+        _cleanup_event(ev_a["id"])
+        _cleanup_event(ev_b["id"])
+        _cleanup_event(past)
+        db.table("attendances").delete().eq("user_id", listener["id"]).execute()
+        _cleanup_user(listener["id"])
+        _cleanup_user(host["id"])
+
+    def test_combines_with_quick_filter(self):
+        cat_a, _ = _get_category_ids(2)
+        host = _create_test_user("qfHost")
+        listener = _create_test_user("qfList")
+
+        past = _make_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        # An upcoming event in user's category (>7 days from now → outside this_week)
+        ev_far = _create_published_event(
+            host["id"], [cat_a], title="Far", days_from_now=20,
+        )
+
+        resp = client.get(
+            "/events?suggested=true&quick_filter=this_week",
+            headers=_auth_header(listener["id"]),
+        )
+        assert resp.status_code == 200
+        ids = {item["id"] for item in resp.json()["items"]}
+        # Suggested narrows to cat_a, this_week excludes events 20 days out
+        assert ev_far["id"] not in ids
+
+        _cleanup_event(ev_far["id"])
+        _cleanup_event(past)
+        db.table("attendances").delete().eq("user_id", listener["id"]).execute()
+        _cleanup_user(listener["id"])
+        _cleanup_user(host["id"])
+
+    def test_private_event_not_surfaced_via_suggested(self):
+        cat_a, _ = _get_category_ids(2)
+        host = _create_test_user("privHost")
+        listener = _create_test_user("privList")
+
+        past = _make_ended_event(host["id"], cat_a)
+        _add_attendance(listener["id"], past, "going")
+
+        # Private event in matching category. Listing currently surfaces a limited
+        # preview of private events for non-host viewers, so the response will
+        # contain it but description/full data is absent. The strict requirement
+        # is that the access boundary holds: the listener cannot get full detail.
+        ev_priv = _create_published_event(
+            host["id"], [cat_a], title="Private Match", visibility="private",
+        )
+
+        # Listener can see it in the list (private events appear in discovery),
+        # but cannot read full detail without an invite/grant.
+        detail_resp = client.get(
+            f"/events/{ev_priv['id']}", headers=_auth_header(listener["id"]),
+        )
+        # Limited responses lack 'description' / 'host_id' fields.
+        body = detail_resp.json()
+        assert "host_id" not in body or body.get("description") is None
+
+        _cleanup_event(ev_priv["id"])
+        _cleanup_event(past)
+        db.table("attendances").delete().eq("user_id", listener["id"]).execute()
+        _cleanup_user(listener["id"])
+        _cleanup_user(host["id"])

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -1100,7 +1100,35 @@ class TestSuggestedFilter:
         _cleanup_user(listener["id"])
         _cleanup_user(host["id"])
 
-    def test_private_event_not_surfaced_via_suggested(self):
+    def test_active_event_attendance_does_not_count_as_signal(self):
+        cat_a, cat_b = _get_category_ids(2)
+        host = _create_test_user("activeHost")
+        listener = _create_test_user("activeList")
+
+        # Listener is going on a currently PUBLISHED (not ended) event in cat_a
+        active = _create_published_event(host["id"], [cat_a], title="Active")
+        _add_attendance(listener["id"], active, "going")
+
+        # New event also in cat_a — but listener's signal comes from a non-ended event,
+        # so no history exists and suggested filter should fall back to default listing
+        ev_new = _create_published_event(host["id"], [cat_b], title="New Other Cat")
+
+        resp = client.get("/events?suggested=true", headers=_auth_header(listener["id"]))
+        assert resp.status_code == 200
+        body = resp.json()
+        # No ended attendance → fallback flag must be set
+        assert body["suggested_fallback"] is True
+        # The cat_b event appears in the default fallback listing
+        ids = {item["id"] for item in body["items"]}
+        assert ev_new["id"] in ids
+
+        _cleanup_event(active)
+        _cleanup_event(ev_new)
+        db.table("attendances").delete().eq("user_id", listener["id"]).execute()
+        _cleanup_user(listener["id"])
+        _cleanup_user(host["id"])
+
+    def test_private_event_access_boundary_preserved_via_suggested(self):
         cat_a, _ = _get_category_ids(2)
         host = _create_test_user("privHost")
         listener = _create_test_user("privList")
@@ -1108,20 +1136,20 @@ class TestSuggestedFilter:
         past = _make_ended_event(host["id"], cat_a)
         _add_attendance(listener["id"], past, "going")
 
-        # Private event in matching category. Listing currently surfaces a limited
-        # preview of private events for non-host viewers, so the response will
-        # contain it but description/full data is absent. The strict requirement
-        # is that the access boundary holds: the listener cannot get full detail.
         ev_priv = _create_published_event(
             host["id"], [cat_a], title="Private Match", visibility="private",
         )
 
-        # Listener can see it in the list (private events appear in discovery),
-        # but cannot read full detail without an invite/grant.
+        # The suggested listing may surface the private event in limited form —
+        # the key requirement is that the access boundary holds at the detail level.
+        resp = client.get("/events?suggested=true", headers=_auth_header(listener["id"]))
+        assert resp.status_code == 200
+        assert resp.json()["suggested_fallback"] is False
+
+        # Non-invited user must not be able to read full event detail.
         detail_resp = client.get(
             f"/events/{ev_priv['id']}", headers=_auth_header(listener["id"]),
         )
-        # Limited responses lack 'description' / 'host_id' fields.
         body = detail_resp.json()
         assert "host_id" not in body or body.get("description") is None
 

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -1107,7 +1107,7 @@ class TestSuggestedFilter:
 
         # Listener is going on a currently PUBLISHED (not ended) event in cat_a
         active = _create_published_event(host["id"], [cat_a], title="Active")
-        _add_attendance(listener["id"], active, "going")
+        _add_attendance(listener["id"], active["id"], "going")
 
         # New event also in cat_a — but listener's signal comes from a non-ended event,
         # so no history exists and suggested filter should fall back to default listing
@@ -1122,8 +1122,8 @@ class TestSuggestedFilter:
         ids = {item["id"] for item in body["items"]}
         assert ev_new["id"] in ids
 
-        _cleanup_event(active)
-        _cleanup_event(ev_new)
+        _cleanup_event(active["id"])
+        _cleanup_event(ev_new["id"])
         db.table("attendances").delete().eq("user_id", listener["id"]).execute()
         _cleanup_user(listener["id"])
         _cleanup_user(host["id"])


### PR DESCRIPTION
Closes #284

Backend sub-issue of #277.

## Summary

Adds the backend support for the Discovery page Suggested filter. Authenticated users can now call `GET /events?suggested=true` to restrict discovery results to events whose categories overlap with categories from their past attended ended events.

---

## What changed

### API / response contract
- Added the `suggested` query parameter to `GET /events`.
- Added `suggested_fallback` to `EventListResponse` so clients can detect when a user has no attended-history signal and the backend returned the normal discovery ordering instead.

### Recommendation signal
- Added `attendance_repo.get_attended_ended_event_categories(...)`.
- The signal only uses attendances with status `going` on events whose status is `ended`.
- Guests, or authenticated users with no matching history, fall back to the existing default listing behavior.

### Discovery filtering
- `event_repo.list_events(...)` now accepts `suggested_category_ids`.
- The suggested category event-id set is intersected with the existing whitelist pipeline, so it composes with search, category, accessibility, location, quick-filter, personal, and visibility filters.
- Existing private/access rules are not bypassed. Cancelled/ended events are still excluded by the normal future-event listing rules.

### Tests
- Added suggested-filter coverage to `backend/tests/test_discovery.py` for:
  - matching future events from categories in past attended ended events
  - fallback when the user has no attended-history categories
  - guest behavior
  - intersection with an explicit category filter
  - exclusion of non-ended attendance history from the suggestion signal
  - preservation of private-event access behavior

---

## Verification

- `python -m compileall app tests/test_discovery.py` — clean
- `ruff check app tests/test_discovery.py` — clean
- `pytest -v -ra tests/test_discovery.py -k SuggestedFilter` — could not complete in my current local environment because the configured Supabase host was not resolvable (`httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known`). The failures happened while the test fixture was trying to create/query test data, before assertion-level validation.

## Test plan

- [ ] Run `pytest -v -ra backend/tests/test_discovery.py -k SuggestedFilter` in an environment with the test Supabase connection available.
- [ ] As an authenticated user with ended attended events, call `GET /events?suggested=true` and confirm returned events overlap with past attended categories.
- [ ] As an authenticated user with no ended attended history, call `GET /events?suggested=true` and confirm normal discovery results are returned with `suggested_fallback: true`.
- [ ] As a guest, call `GET /events?suggested=true` and confirm it behaves like the normal discovery listing.
