### PR TITLE
feat(mobile): render event_recommended notifications (issue #280)

### DIFF
--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/notifications/NotificationScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/notifications/NotificationScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
@@ -264,6 +265,21 @@ private fun NotificationCard(
 
         // Content
         Column(modifier = Modifier.weight(1f)) {
+            if (notification.type == "event_recommended") {
+                Surface(
+                    shape = RoundedCornerShape(6.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    Text(
+                        text = "Recommended for you",
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+            }
             Text(
                 text = notification.message,
                 fontSize = 14.sp,
@@ -300,6 +316,7 @@ private fun notificationIcon(type: String): ImageVector = when (type) {
     "access_request" -> Icons.Default.PersonAdd
     "access_approved" -> Icons.Default.CheckCircle
     "access_rejected" -> Icons.Default.Cancel
+    "event_recommended" -> Icons.Default.AutoAwesome
     else -> Icons.Default.Notifications
 }
 
@@ -311,6 +328,7 @@ private fun notificationIconBg(type: String, isRead: Boolean): Color {
         "event_cancelled", "event_deleted", "access_rejected" ->
             MaterialTheme.colorScheme.error.copy(alpha = alpha)
         "access_approved" -> Color(0xFF4CAF50).copy(alpha = alpha)
+        "event_recommended" -> MaterialTheme.colorScheme.primary.copy(alpha = alpha)
         else -> MaterialTheme.colorScheme.tertiary.copy(alpha = alpha)
     }
 }
@@ -322,6 +340,7 @@ private fun notificationIconTint(type: String, isRead: Boolean): Color {
         "event_cancelled", "event_deleted", "access_rejected" ->
             MaterialTheme.colorScheme.error.copy(alpha = alpha)
         "access_approved" -> Color(0xFF4CAF50).copy(alpha = alpha)
+        "event_recommended" -> MaterialTheme.colorScheme.primary.copy(alpha = alpha)
         else -> MaterialTheme.colorScheme.tertiary.copy(alpha = alpha)
     }
 }


### PR DESCRIPTION
## Summary

Mobile side of #275 — backend (#278) emits `event_recommended` notifications, but the mobile feed was rendering them with the generic fallback icon and no visual cue.

- `notificationIcon`/`notificationIconBg`/`notificationIconTint` now map `event_recommended` → `AutoAwesome` + primary tint, keeping the existing read/unread alpha rules.
- Adds a small *"Recommended for you"* pill above the message body, type-gated so other notification types are untouched.
- Tap-to-open + mark-as-read already route through the type-agnostic `NotificationCard` click handler ([NotificationScreen.kt:198](https://github.com/bounswe/bounswe2026group9/blob/main/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/notifications/NotificationScreen.kt#L198)) and `NavGraph` ([NavGraph.kt:130](https://github.com/bounswe/bounswe2026group9/blob/main/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/navigation/NavGraph.kt#L130)) — no wiring changes needed.
- 60s notification polling ([NavGraph.kt:90](https://github.com/bounswe/bounswe2026group9/blob/main/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/navigation/NavGraph.kt#L90)) and `unread_count` are type-agnostic, so the new type lights up the bell badge automatically.

Single-file diff, 19 lines added.

## Issue task coverage

- [x] Mobile: render `event_recommended` notifications and route to event detail on tap

## Test plan

- [ ] Account A has prior `going` attendance on an `ended` event in category X
- [ ] Account B publishes a new event in category X → wait ≤ 60s for poll → A's bell shows the unread badge
- [ ] Open notifications → new entry shows the AutoAwesome icon + primary tint + *"Recommended for you"* pill
- [ ] Tap the entry → marked as read, navigates to the event detail screen
- [ ] Other notification types (`event_updated`, `access_approved`, etc.) render exactly as before
- [ ] If the recommended event was deleted between emission and tap (`event_id` null), the card is still readable but doesn't navigate (existing fallback)

Refs #275
Closes #280