### PR TITLE
feat(mobile): "Suggested for you" filter on Discovery (issue #286)

### DIFF
--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/remote/ApiService.kt
@@ -80,7 +80,13 @@ data class EventListResponse(
     val total: Int,
     val page: Int,
     val page_size: Int,
-    val total_pages: Int
+    val total_pages: Int,
+    /**
+     * True when the caller asked for `suggested=true` but the server fell back to default
+     * ordering (no past attendance / no category match). Lets the UI show a hint.
+     * Older backends omit the field; Gson defaults it to false.
+     */
+    val suggested_fallback: Boolean = false
 )
 
 // ── Bookmark & Attendance ─────────────────────────────────────────────────────
@@ -337,6 +343,7 @@ interface ApiService {
         @Query("captions") captions: Boolean? = null,
         @Query("quiet_friendly") quietFriendly: Boolean? = null,
         @Query("sort") sort: String? = null,
+        @Query("suggested") suggested: Boolean? = null,
         @Query("page") page: Int = 1,
         @Query("page_size") pageSize: Int = 20
     ): EventListResponse

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/data/repository/EventRepository.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/data/repository/EventRepository.kt
@@ -27,6 +27,7 @@ class EventRepository {
         nearLat: Double? = null,
         nearLng: Double? = null,
         radiusKm: Double? = null,
+        suggested: Boolean? = null,
         page: Int = 1,
         pageSize: Int = 20
     ): Result<EventListResponse> {
@@ -47,6 +48,7 @@ class EventRepository {
                 captions = captions,
                 quietFriendly = quietFriendly,
                 sort = sort,
+                suggested = suggested,
                 page = page,
                 pageSize = pageSize
             )
@@ -54,9 +56,10 @@ class EventRepository {
         } catch (e: retrofit2.HttpException) {
             if (e.code() == 401 && token != null) {
                 Log.w("EventRepository", "Token rejected (401), retrying without auth")
+                // Suggested requires auth — drop it on the unauth retry so the request still succeeds.
                 return getEvents(null, search, categoryId, quickFilter,
                     wheelchair, accessibleRestroom, elevator, seating, captions,
-                    quietFriendly, sort, nearLat, nearLng, radiusKm, page, pageSize)
+                    quietFriendly, sort, nearLat, nearLng, radiusKm, null, page, pageSize)
             }
             val body = e.response()?.errorBody()?.string() ?: "Unknown error"
             Log.e("EventRepository", "getEvents HTTP ${e.code()}: $body")

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryScreen.kt
@@ -135,11 +135,30 @@ fun DiscoveryScreen(
         },
         containerColor = MaterialTheme.colorScheme.background
     ) { padding ->
-        Box(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
         ) {
+            // Empty-history hint for the Suggested filter (issue #277). Shown above the listing
+            // whenever the chip is on AND the server signalled it had no history to bias by.
+            if (uiState.suggestedActive && uiState.suggestedFallback) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.secondaryContainer
+                ) {
+                    Text(
+                        "Attend events to get personalised suggestions. Showing default results.",
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                }
+            }
+            Box(modifier = Modifier.fillMaxSize().weight(1f)) {
             when {
                 uiState.isLoading -> {
                     LazyColumn(
@@ -205,6 +224,7 @@ fun DiscoveryScreen(
                     }
                 }
             }
+            }
         }
     }
 
@@ -228,6 +248,7 @@ fun DiscoveryScreen(
                 onSeatingToggle = viewModel::onSeatingToggle,
                 onCaptionsToggle = viewModel::onCaptionsToggle,
                 onQuietFriendlyToggle = viewModel::onQuietFriendlyToggle,
+                onSuggestedToggle = viewModel::onSuggestedToggle,
                 onProximitySortToggle = {
                     if (uiState.proximitySort) {
                         viewModel.disableProximitySort()
@@ -484,12 +505,14 @@ private fun FilterSheetContent(
     onSeatingToggle: () -> Unit,
     onCaptionsToggle: () -> Unit,
     onQuietFriendlyToggle: () -> Unit,
+    onSuggestedToggle: () -> Unit,
     onProximitySortToggle: () -> Unit,
     onClear: () -> Unit,
     onApply: () -> Unit
 ) {
     val hasAnyFilter = uiState.selectedQuickFilter != null || uiState.selectedCategoryId != null ||
-        uiState.bookmarkedOnly || uiState.goingOnly || uiState.hasAccessibilityFilter || uiState.proximitySort
+        uiState.bookmarkedOnly || uiState.goingOnly || uiState.hasAccessibilityFilter ||
+        uiState.proximitySort || uiState.suggestedActive
 
     Column(modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)) {
         // Header
@@ -534,6 +557,7 @@ private fun FilterSheetContent(
                     }
                 }
                 if (isLoggedIn) {
+                    FilterPill("✨ Suggested for you", uiState.suggestedActive, onSuggestedToggle)
                     FilterPill("🔖 Bookmarked", uiState.bookmarkedOnly, onBookmarkedToggle)
                     FilterPill("✓ Going", uiState.goingOnly, onGoingToggle)
                 }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryUiState.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryUiState.kt
@@ -23,6 +23,11 @@ data class DiscoveryUiState(
     val proximitySort: Boolean = false,
     val nearLat: Double? = null,
     val nearLng: Double? = null,
+    // "Suggested for you" — biases listing toward categories the user has previously attended.
+    // Auth-only; chip is hidden for guests.
+    val suggestedActive: Boolean = false,
+    /** Server flag: true when the user has no past-attendance history so the response fell back to default ordering. */
+    val suggestedFallback: Boolean = false,
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,
     val errorMessage: String? = null,

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
@@ -65,6 +65,18 @@ class DiscoveryViewModel(
         )
     }
 
+    fun onSuggestedToggle() {
+        // Auth-only — guard at the call site as well, but defensive here too.
+        if (token == null) return
+        // State-only toggle, like the other quick-filter chips. The user applies the
+        // change via the "Apply" button (applyFilters), which triggers loadEvents.
+        // Always clear stale fallback flag — the next response will repopulate it.
+        _uiState.value = _uiState.value.copy(
+            suggestedActive = !_uiState.value.suggestedActive,
+            suggestedFallback = false
+        )
+    }
+
     // Accessibility toggles
     fun onWheelchairToggle() {
         _uiState.value = _uiState.value.copy(wheelchair = !_uiState.value.wheelchair)
@@ -164,7 +176,9 @@ class DiscoveryViewModel(
             quietFriendly = false,
             proximitySort = false,
             nearLat = null,
-            nearLng = null
+            nearLng = null,
+            suggestedActive = false,
+            suggestedFallback = false
         )
         loadEvents(reset = true)
     }
@@ -183,6 +197,7 @@ class DiscoveryViewModel(
         if (s.captions) count++
         if (s.quietFriendly) count++
         if (s.proximitySort) count++
+        if (s.suggestedActive) count++
         return count
     }
 
@@ -210,6 +225,8 @@ class DiscoveryViewModel(
                 sort = if (state.proximitySort && state.nearLat != null) "distance" else null,
                 nearLat = state.nearLat,
                 nearLng = state.nearLng,
+                // Suggested only goes to the wire when the chip is on AND the user is signed in.
+                suggested = if (state.suggestedActive && token != null) true else null,
                 page = page
             ).fold(
                 onSuccess = { response ->
@@ -221,7 +238,9 @@ class DiscoveryViewModel(
                         totalPages = response.total_pages,
                         isLoading = false,
                         isLoadingMore = false,
-                        errorMessage = null
+                        errorMessage = null,
+                        // Only meaningful when the user actually asked for suggested.
+                        suggestedFallback = if (state.suggestedActive) response.suggested_fallback else false
                     )
                 },
                 onFailure = { e ->


### PR DESCRIPTION
## Summary

Mobile side of #277. Adds an auth-only *"Suggested for you"* quick chip in the Discovery filter sheet that forwards `suggested=true` to `GET /events`, biasing the listing toward categories the user has previously attended.

When the server signals the caller has no past-attendance history (`suggested_fallback=true` in the response), a small banner above the listing tells the user they'll start getting personalised suggestions once they attend events — the request still returns the default ordering so the page is never blank.

Toggling the chip is **state-only**, matching the existing bookmarked / going / quick-filter chips — changes apply via the existing *Apply* button so users can compose multiple filters in one round-trip. The 401-retry path drops the `suggested` flag (it requires auth) so a stale token never breaks the page.

## Issue task coverage

- [x] Mobile: "Suggested for you" chip / quick filter on the Discovery screen
- [x] Auth-only behaviour — chip hidden for guests (matches existing bookmarked / going chip pattern)
- [x] Empty-history fallback hint above the listing

## Backend dependency

Backend support lands in **#301** (still open at the time of this PR). The mobile request format follows that PR's contract — until it merges, `suggested=true` is silently ignored by the BE and `suggested_fallback` defaults to `false` via Gson, so this PR is safe to merge in either order.

## Test plan

- [ ] Guest user: open the filter sheet → no *Suggested for you* chip visible
- [ ] Logged-in user with `going` history on `ended` events → chip toggle ON → Apply → listing filters to that category set; banner not shown
- [ ] Logged-in user with no attendance history → chip toggle ON → Apply → default ordering returns; banner *"Attend events to get personalised suggestions"* appears above the list
- [ ] Combine *Suggested* + a category chip → BE intersection (server-side); private events stay hidden
- [ ] *Clear All* in filter sheet wipes the suggested flag and the banner together
- [ ] Sign out while chip was active → chip disappears, listing reloads as guest, no `suggested` query sent

Refs #277
Closes #286