### PR TITLE
chore(ci): point backend CI at dedicated test Supabase project

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,10 +19,13 @@ jobs:
         working-directory: backend
 
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+      # CI runs against a dedicated test Supabase project so prod data is
+      # never polluted by integration tests. The deploy workflow keeps using
+      # the unprefixed prod secrets — only this workflow points at TEST_*.
+      SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.TEST_SUPABASE_KEY }}
+      JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
+      JWT_REFRESH_SECRET: ${{ secrets.TEST_JWT_REFRESH_SECRET }}
       ENVIRONMENT: development
       TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -48,10 +51,13 @@ jobs:
         working-directory: backend
 
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+      # CI runs against a dedicated test Supabase project so prod data is
+      # never polluted by integration tests. The deploy workflow keeps using
+      # the unprefixed prod secrets — only this workflow points at TEST_*.
+      SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.TEST_SUPABASE_KEY }}
+      JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
+      JWT_REFRESH_SECRET: ${{ secrets.TEST_JWT_REFRESH_SECRET }}
       ENVIRONMENT: development
       TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -108,10 +114,13 @@ jobs:
         working-directory: backend
 
     env:
-      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+      # CI runs against a dedicated test Supabase project so prod data is
+      # never polluted by integration tests. The deploy workflow keeps using
+      # the unprefixed prod secrets — only this workflow points at TEST_*.
+      SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.TEST_SUPABASE_KEY }}
+      JWT_SECRET: ${{ secrets.TEST_JWT_SECRET }}
+      JWT_REFRESH_SECRET: ${{ secrets.TEST_JWT_REFRESH_SECRET }}
       ENVIRONMENT: development
       TEST_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard }}
 


### PR DESCRIPTION
## Summary

Backend integration tests previously ran against the **production** Supabase project — the same one that serves real users. Cleanup fixtures mostly held the line, but any test that crashed mid-flight, or any parallel run that hit a race, could leak rows into prod tables. Issue #153 also wants more end-to-end + load tests, which would make the contention worse.

This PR points all three CI jobs (lint, unit-fast, integration-sharded) at a freshly provisioned, schema-identical test Supabase project. The deploy workflow keeps using the unprefixed prod secrets — only `backend-ci.yml` is moved.

## Required GitHub Actions secrets (added by maintainer alongside this PR)

- `TEST_SUPABASE_URL`
- `TEST_SUPABASE_KEY`           — service_role of the test project
- `TEST_JWT_SECRET`             — random 32+ char, distinct from prod
- `TEST_JWT_REFRESH_SECRET`     — random 32+ char, distinct from prod

Without these, the CI run will fail on missing env vars — that is the only thing the secrets gate.

## Test schema provisioning

Replayed every file in `backend/sql/` against the new project via `psql` in order (001 → 017). Verified post-apply:

- 21 public tables present (`attendances`, `bookmarks`, …, `venue_metadata`)
- `pg_cron` schedules registered (auto-end events + token cleanup)
- Atomic event create/update RPCs installed (013 supersedes 009/010)
- `unaccent` extension enabled
- `event_recommended` in the `notifications.type` CHECK constraint

Same region as prod (eu-central-1) so latency profile is comparable.

## Why now

#153 will add scenario tests (report → moderation → sanction; access-request flow with notifications; capacity → "Full"). Running those against prod is a non-starter — moderation tests in particular create reports against real users.

## Test plan

- [ ] CI run on this PR: lint job goes green
- [ ] CI run on this PR: unit-fast goes green
- [ ] CI run on this PR: each of the 5 integration shards (auth-core, events, discovery, comments-invites, media-notifications) goes green
- [ ] After merge: open a tiny no-op PR touching `backend/` only and confirm the CI run hits the new test project (look at the Supabase dashboard for the test project — table row counts should grow during the run, then revert as cleanup fires)
- [ ] Confirm the deploy workflow on `main` still pushes to the prod project (no regression)

Refs #153