### PR TITLE
feat(backend): QR check-in for events (issue #231)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -107,6 +107,7 @@ jobs:
               tests/test_images.py
               tests/test_bookmarks.py
               tests/test_attendances.py
+              tests/test_checkin.py
               tests/test_notifications.py
               tests/test_notification_emitter.py
     defaults:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.routers import (
     notifications,
     users,
 )
+from app.routers.attendances import _qr_router
 
 API_DESCRIPTION = """
 Backend API for **Social Event Mapper** — a platform for discovering, hosting,
@@ -166,6 +167,7 @@ app.include_router(invites.router)
 app.include_router(notifications.router)
 app.include_router(bookmarks.router)
 app.include_router(attendances.router)
+app.include_router(_qr_router)
 app.include_router(users.router)
 
 

--- a/backend/app/models/attendance.py
+++ b/backend/app/models/attendance.py
@@ -24,3 +24,41 @@ class AttendanceResponse(AppBaseModel):
     user_id: UUID
     status: str
     marked_at: datetime
+
+
+# ── QR / check-in ─────────────────────────────────────────────────────────────
+
+class QrTokenResponse(AppBaseModel):
+    """Returned by GET /attendances/me/{event_id}/qr."""
+    token: str
+    expires_at: datetime | None = None
+
+
+class CheckInRequest(AppBaseModel):
+    """Body for POST /events/{event_id}/check-in.
+
+    Exactly one of `token` (scanned QR payload) or `user_id` (manual fallback)
+    must be provided.
+    """
+    token: str | None = None
+    user_id: UUID | None = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {"token": "<signed-qr-payload>"}
+        }
+    )
+
+
+class CheckInResultResponse(AppBaseModel):
+    """Returned on a successful check-in (HTTP 200)."""
+    user_id: UUID
+    username: str
+    checked_in_at: datetime
+
+
+class AttendeeStatusItem(AppBaseModel):
+    """One row in GET /events/{event_id}/attendees."""
+    user_id: UUID
+    username: str
+    checked_in_at: datetime | None = None

--- a/backend/app/repositories/attendance.py
+++ b/backend/app/repositories/attendance.py
@@ -6,7 +6,7 @@ from supabase import Client
 def get_attendance(db: Client, user_id: str, event_id: str) -> dict | None:
     result = (
         db.table("attendances")
-        .select("id,user_id,event_id,status,marked_at")
+        .select("id,user_id,event_id,status,marked_at,check_in_token,checked_in_at")
         .eq("user_id", user_id)
         .eq("event_id", event_id)
         .execute()
@@ -30,9 +30,65 @@ def update_attendance(db: Client, user_id: str, event_id: str, status: str) -> d
     return result.data[0]
 
 
+def update_attendance_token(db: Client, user_id: str, event_id: str, token: str | None) -> dict:
+    """Set or clear the check-in token for an attendance record."""
+    result = (
+        db.table("attendances")
+        .update({"check_in_token": token})
+        .eq("user_id", user_id)
+        .eq("event_id", event_id)
+        .execute()
+    )
+    return result.data[0]
+
+
 def delete_attendance(db: Client, user_id: str, event_id: str) -> None:
     db.table("attendances").delete().eq("user_id", user_id).eq("event_id", event_id).execute()
 
+
+def get_attendance_by_token(db: Client, token: str) -> dict | None:
+    """Look up an attendance record by its check-in token."""
+    result = (
+        db.table("attendances")
+        .select("id,user_id,event_id,status,marked_at,check_in_token,checked_in_at")
+        .eq("check_in_token", token)
+        .execute()
+    )
+    return result.data[0] if result.data else None
+
+
+def mark_checked_in(db: Client, attendance_id: str) -> dict:
+    """Set checked_in_at = now() for the given attendance row."""
+    result = (
+        db.table("attendances")
+        .update({"checked_in_at": "now()"})
+        .eq("id", attendance_id)
+        .execute()
+    )
+    return result.data[0]
+
+
+def list_going_attendees_with_checkin(db: Client, event_id: str) -> list[dict]:
+    """Return all going attendees for the event, with their check-in status.
+
+    Joins with users to get usernames.
+    """
+    result = (
+        db.table("attendances")
+        .select("user_id,checked_in_at,users!inner(username)")
+        .eq("event_id", event_id)
+        .eq("status", "going")
+        .order("marked_at")
+        .execute()
+    )
+    rows = []
+    for row in (result.data or []):
+        rows.append({
+            "user_id": row["user_id"],
+            "username": row["users"]["username"],
+            "checked_in_at": row["checked_in_at"],
+        })
+    return rows
 
 
 def get_going_user_ids_for_event(db: Client, event_id: str) -> list[str]:

--- a/backend/app/routers/attendances.py
+++ b/backend/app/routers/attendances.py
@@ -6,12 +6,14 @@ from fastapi import APIRouter, Depends, status
 
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
-from app.models.attendance import AttendanceResponse, AttendanceStatusRequest
+from app.models.attendance import AttendanceResponse, AttendanceStatusRequest, QrTokenResponse
 from app.models.errors import AUTH_RESPONSES, NOT_FOUND_RESPONSE
 from app.models.user import MessageResponse
-from app.services.attendance import remove_attendance, set_attendance
+from app.services.attendance import get_my_qr, remove_attendance, set_attendance
 
 router = APIRouter(prefix="/events/{event_id}/attendance", tags=["attendances"])
+
+_qr_router = APIRouter(prefix="/attendances", tags=["attendances"])
 
 
 @router.post(
@@ -44,3 +46,22 @@ def remove_attendance_endpoint(
     db = get_supabase()
     remove_attendance(db, str(event_id), user_id)
     return MessageResponse(message="Attendance removed successfully")
+
+
+@_qr_router.get(
+    "/me/{event_id}/qr",
+    response_model=QrTokenResponse,
+    summary="Get my check-in QR token",
+    description=(
+        "Returns the signed QR payload for the authenticated Going user. "
+        "Render the `token` field as a QR code. "
+        "Returns 404 if the caller is not Going for this event."
+    ),
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE},
+)
+def get_my_qr_endpoint(
+    event_id: UUID,
+    user_id: str = Depends(get_current_user_id),
+):
+    db = get_supabase()
+    return get_my_qr(db, str(event_id), user_id)

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, UploadFile
 
 from app.database import get_supabase
 from app.middleware.auth import get_current_user_id
+from app.models.attendance import AttendeeStatusItem, CheckInRequest, CheckInResultResponse
 from app.models.errors import (
     AUTH_RESPONSES,
     CONFLICT_RESPONSE,
@@ -25,6 +26,7 @@ from app.models.event import (
 )
 from app.models.geojson import GeoJSONFeatureCollection
 from app.models.user import MessageResponse
+from app.services.attendance import check_in, list_event_attendees
 from app.services.auth import decode_access_token
 from app.services.event import (
     change_event_status,
@@ -435,3 +437,49 @@ def get_similar_events_endpoint(
 ):
     db = get_supabase()
     return get_similar_events(db, str(event_id), user_id)
+
+
+# ── QR check-in ───────────────────────────────────────────────────────────────
+
+@router.post(
+    "/{event_id}/check-in",
+    response_model=CheckInResultResponse,
+    summary="Check in an attendee (host only)",
+    description=(
+        "Validates a scanned QR token or a manual `user_id` and marks the "
+        "attendee as checked in. Host-only. Returns 400 for tampered/wrong-event "
+        "payloads, 403 for non-hosts, 404 when the attendee is not Going, "
+        "and 409 on a duplicate scan."
+    ),
+    responses={
+        **AUTH_RESPONSES,
+        **NOT_FOUND_RESPONSE,
+        **FORBIDDEN_RESPONSE,
+        **CONFLICT_RESPONSE,
+    },
+)
+def check_in_endpoint(
+    event_id: UUID,
+    body: CheckInRequest,
+    host_user_id: str = Depends(get_current_user_id),
+):
+    db = get_supabase()
+    return check_in(db, str(event_id), host_user_id, body)
+
+
+@router.get(
+    "/{event_id}/attendees",
+    response_model=list[AttendeeStatusItem],
+    summary="List going attendees with check-in status (host only)",
+    description=(
+        "Returns the full roster of Going attendees with their check-in timestamp. "
+        "Host-only. Returns 403 for non-hosts."
+    ),
+    responses={**AUTH_RESPONSES, **NOT_FOUND_RESPONSE, **FORBIDDEN_RESPONSE},
+)
+def list_attendees_endpoint(
+    event_id: UUID,
+    host_user_id: str = Depends(get_current_user_id),
+):
+    db = get_supabase()
+    return list_event_attendees(db, str(event_id), host_user_id)

--- a/backend/app/services/attendance.py
+++ b/backend/app/services/attendance.py
@@ -1,15 +1,67 @@
 """Attendance service — business logic for event attendance."""
 
+import base64
+import hashlib
+import hmac as _hmac
+import json
+import time
 from datetime import UTC, datetime
 
 from fastapi import HTTPException, status
 from supabase import Client
 
-from app.models.attendance import AttendanceResponse
+from app.config import settings
+from app.models.attendance import (
+    AttendanceResponse,
+    AttendeeStatusItem,
+    CheckInRequest,
+    CheckInResultResponse,
+    QrTokenResponse,
+)
 from app.repositories import attendance as attendance_repo
 from app.repositories import event as event_repo
 from app.repositories import user as user_repo
 
+# ── Token helpers ─────────────────────────────────────────────────────────────
+
+def _generate_check_in_token(event_id: str, user_id: str) -> str:
+    """Return a compact HMAC-SHA256-signed QR payload.
+
+    Format: base64url(payload_json).hex_signature
+    The payload carries event_id and user_id so the host-side validator
+    can detect wrong-event scans without a database round-trip.
+    """
+    payload = json.dumps(
+        {"eid": event_id, "uid": user_id, "iat": int(time.time())},
+        separators=(",", ":")
+    ).encode()
+    b64 = base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+    sig = _hmac.new(settings.JWT_SECRET.encode(), b64.encode(), hashlib.sha256).hexdigest()
+    return f"{b64}.{sig}"
+
+
+def _verify_check_in_token(token: str) -> dict | None:
+    """Decode and verify a check-in token.
+
+    Returns the payload dict on success, None if the signature is invalid
+    or the token is malformed.  Timing-safe comparison prevents side-channel
+    attacks.
+    """
+    parts = token.split(".", 1)
+    if len(parts) != 2:
+        return None
+    b64, sig = parts
+    expected = _hmac.new(settings.JWT_SECRET.encode(), b64.encode(), hashlib.sha256).hexdigest()
+    if not _hmac.compare_digest(expected, sig):
+        return None
+    try:
+        padding = "=" * (4 - len(b64) % 4)
+        return json.loads(base64.urlsafe_b64decode(b64 + padding))
+    except Exception:
+        return None
+
+
+# ── Core attendance logic ─────────────────────────────────────────────────────
 
 def set_attendance(db: Client, event_id: str, user_id: str, target_status: str) -> AttendanceResponse:
     if target_status != "going":
@@ -53,26 +105,28 @@ def set_attendance(db: Client, event_id: str, user_id: str, target_status: str) 
     existing = attendance_repo.get_attendance(db, user_id, event_id)
 
     # Capacity check only relevant when switching to 'going'
-    if target_status == "going":
-        # we check if existing is not going to avoid rejecting someone already going
-        is_already_going = existing and existing["status"] == "going"
-        if not is_already_going and event["attendee_limit"] is not None:
-            if event["attendee_count"] >= event["attendee_limit"]:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Event attendee limit reached",
-                )
+    is_already_going = existing and existing["status"] == "going"
+    if not is_already_going and event["attendee_limit"] is not None:
+        if event["attendee_count"] >= event["attendee_limit"]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Event attendee limit reached",
+            )
+
+    token = _generate_check_in_token(event_id, user_id)
 
     if not existing:
         att = attendance_repo.insert_attendance(db, {
             "user_id": user_id,
             "event_id": event_id,
             "status": target_status,
+            "check_in_token": token,
         })
     elif existing["status"] != target_status:
         att = attendance_repo.update_attendance(db, user_id, event_id, target_status)
+        att = attendance_repo.update_attendance_token(db, user_id, event_id, token)
     else:
-        # no change needed
+        # Already going — keep existing token (idempotent)
         att = existing
 
     return AttendanceResponse(
@@ -90,3 +144,128 @@ def remove_attendance(db: Client, event_id: str, user_id: str) -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attendance not found")
 
     attendance_repo.delete_attendance(db, user_id, event_id)
+
+
+# ── QR / check-in ─────────────────────────────────────────────────────────────
+
+def get_my_qr(db: Client, event_id: str, user_id: str) -> QrTokenResponse:
+    """Return the signed QR token for the authenticated Going user."""
+    attendance = attendance_repo.get_attendance(db, user_id, event_id)
+    if not attendance or attendance["status"] != "going":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="You are not going to this event",
+        )
+
+    token = attendance.get("check_in_token")
+    if not token:
+        # Backfill: attendance predates the QR feature — generate now.
+        token = _generate_check_in_token(event_id, user_id)
+        attendance_repo.update_attendance_token(db, user_id, event_id, token)
+
+    event = event_repo.get_event_by_id(db, event_id)
+    expires_at = datetime.fromisoformat(event["end_datetime"]) if event else None
+
+    return QrTokenResponse(token=token, expires_at=expires_at)
+
+
+def check_in(db: Client, event_id: str, host_user_id: str, body: CheckInRequest) -> CheckInResultResponse:
+    """Validate a QR scan or manual user_id and mark the attendee as checked in."""
+    event = event_repo.get_event_by_id(db, event_id)
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    if event["host_id"] != host_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the event host can check in attendees",
+        )
+
+    if event["status"] not in ("published", "updated"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Check-in is only available for active events",
+        )
+
+    if body.token is not None:
+        attendance = _resolve_by_token(body.token, event_id, db)
+    elif body.user_id is not None:
+        attendance = _resolve_by_user_id(str(body.user_id), event_id, db)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide either 'token' or 'user_id'",
+        )
+
+    if attendance["checked_in_at"] is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Attendee already checked in",
+        )
+
+    updated = attendance_repo.mark_checked_in(db, attendance["id"])
+    user = user_repo.get_user_by_id(db, attendance["user_id"])
+
+    return CheckInResultResponse(
+        user_id=updated["user_id"],
+        username=user["username"] if user else attendance["user_id"],
+        checked_in_at=updated["checked_in_at"],
+    )
+
+
+def _resolve_by_token(token: str, event_id: str, db: Client) -> dict:
+    """Decode the signed token and return the attendance row, raising on any validation failure."""
+    payload = _verify_check_in_token(token)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid QR code",
+        )
+
+    if payload.get("eid") != event_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="QR code is for a different event",
+        )
+
+    attendance = attendance_repo.get_attendance_by_token(db, token)
+    if not attendance or attendance["status"] != "going":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Attendee is not on the Going list",
+        )
+    return attendance
+
+
+def _resolve_by_user_id(user_id: str, event_id: str, db: Client) -> dict:
+    """Return the going attendance for user_id, raising 404 if not found."""
+    attendance = attendance_repo.get_attendance(db, user_id, event_id)
+    if not attendance or attendance["status"] != "going":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Attendee is not on the Going list",
+        )
+    return attendance
+
+
+def list_event_attendees(db: Client, event_id: str, host_user_id: str) -> list[AttendeeStatusItem]:
+    """Return the full going-attendee roster for the host."""
+    event = event_repo.get_event_by_id(db, event_id)
+    if not event:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+
+    if event["host_id"] != host_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the event host can view the attendee list",
+        )
+
+    rows = attendance_repo.list_going_attendees_with_checkin(db, event_id)
+    return [
+        AttendeeStatusItem(
+            user_id=row["user_id"],
+            username=row["username"],
+            checked_in_at=row["checked_in_at"],
+        )
+        for row in rows
+    ]

--- a/backend/sql/018_add_checkin_to_attendances.sql
+++ b/backend/sql/018_add_checkin_to_attendances.sql
@@ -1,0 +1,15 @@
+-- ================================================================
+-- 018_add_checkin_to_attendances.sql
+-- QR check-in support for the attendances table.
+-- Depends on: 002_create_core_tables.sql (attendances)
+-- ================================================================
+
+-- Signed token issued when the user goes to an event.
+-- Stored so the check-in endpoint can look up by token quickly.
+ALTER TABLE public.attendances
+    ADD COLUMN IF NOT EXISTS check_in_token TEXT UNIQUE,
+    ADD COLUMN IF NOT EXISTS checked_in_at  TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_attendances_check_in_token
+    ON public.attendances (check_in_token)
+    WHERE check_in_token IS NOT NULL;

--- a/backend/tests/test_checkin.py
+++ b/backend/tests/test_checkin.py
@@ -1,0 +1,381 @@
+"""Integration tests for QR check-in — issue #231.
+
+Coverage:
+  - QR issued on Going (200)
+  - QR returns 404 when caller is not going
+  - QR backfill: attendance without a token gets one on first GET
+  - host-only check-in: 403 for non-host
+  - valid QR scan → 200 + checked_in_at set
+  - duplicate scan → 409
+  - tampered payload → 400
+  - wrong-event payload → 400
+  - missing both token and user_id → 400
+  - manual check-in by user_id → 200
+  - attendee list (host-only): 200 + 403 for non-host
+  - un-Going removes the token (QR becomes invalid)
+"""
+
+import io
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from app.database import get_supabase
+from app.main import app
+from app.services.auth import create_access_token
+from tests_support import build_test_identity
+
+client = TestClient(app)
+db = get_supabase()
+
+MOCK_STORAGE_URL = "https://example.com/storage/v1/object/public/event-images/test.jpg"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _auth(user_id: str) -> dict:
+    token = create_access_token(user_id, "test@example.com")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register(prefix: str = "qrtest") -> dict:
+    username, email = build_test_identity(prefix)
+    resp = client.post("/auth/register", json={
+        "username": username,
+        "email": email,
+        "password": "testpass123",
+        "date_of_birth": "2000-01-15",
+    })
+    assert resp.status_code == 201, resp.json()
+    return resp.json()["user"]
+
+
+def _get_category_id() -> str:
+    result = db.table("categories").select("id").eq("is_predefined", True).limit(1).execute()
+    return result.data[0]["id"]
+
+
+def _make_image() -> bytes:
+    img = PILImage.new("RGB", (100, 100), color="green")
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+@patch("app.repositories.image.upload_to_storage", return_value=MOCK_STORAGE_URL)
+def _create_published_event(host_id: str, mock_upload, *, days: int = 5) -> str:  # noqa: ARG001
+    """Create and publish an event; return its id."""
+    cat_id = _get_category_id()
+    start = datetime.now(UTC) + timedelta(days=days)
+    end = start + timedelta(hours=2)
+    body = {
+        "title": f"QR Test Event {uuid.uuid4().hex[:6]}",
+        "description": "Check-in test event",
+        "start_datetime": start.isoformat(),
+        "end_datetime": end.isoformat(),
+        "visibility": "public",
+        "status": "draft",
+        "is_age_restricted": False,
+        "category_ids": [cat_id],
+        "locations": [{"name": "Venue", "latitude": 41.0, "longitude": 29.0}],
+    }
+    create_resp = client.post("/events", headers=_auth(host_id), json=body)
+    assert create_resp.status_code == 201, create_resp.json()
+    event_id = create_resp.json()["id"]
+
+    img_bytes = _make_image()
+    client.post(
+        f"/events/{event_id}/images",
+        headers=_auth(host_id),
+        files={"file": ("test.jpg", io.BytesIO(img_bytes), "image/jpeg")},
+    )
+
+    pub = client.patch(
+        f"/events/{event_id}/status",
+        headers=_auth(host_id),
+        json={"status": "published"},
+    )
+    assert pub.status_code == 200, pub.json()
+    return event_id
+
+
+def _go(attendee_id: str, event_id: str) -> None:
+    resp = client.post(
+        f"/events/{event_id}/attendance",
+        headers=_auth(attendee_id),
+        json={"status": "going"},
+    )
+    assert resp.status_code == 200, resp.json()
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestGetMyQr:
+    def test_qr_returned_after_going(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        resp = client.get(f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"]))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "token" in data
+        assert len(data["token"]) > 10
+
+    def test_qr_404_when_not_going(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+
+        resp = client.get(f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"]))
+        assert resp.status_code == 404
+
+    def test_qr_401_without_auth(self):
+        host = _register()
+        event_id = _create_published_event(host["id"])
+
+        resp = client.get(f"/attendances/me/{event_id}/qr")
+        assert resp.status_code == 401
+
+    def test_qr_backfill_for_tokenless_attendance(self):
+        """Attendances that pre-date the QR migration get a token on first GET."""
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        # Directly null-out the token to simulate a pre-migration row.
+        db.table("attendances").update({"check_in_token": None}).eq(
+            "user_id", attendee["id"]
+        ).eq("event_id", event_id).execute()
+
+        resp = client.get(f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"]))
+        assert resp.status_code == 200
+        assert resp.json()["token"]
+
+
+class TestCheckIn:
+    def test_valid_qr_scan(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_id"] == attendee["id"]
+        assert data["checked_in_at"] is not None
+
+    def test_duplicate_scan_returns_409(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+        second = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+        assert second.status_code == 409
+
+    def test_tampered_payload_returns_400(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        tampered = qr_token[:-4] + "xxxx"
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": tampered},
+        )
+        assert resp.status_code == 400
+
+    def test_wrong_event_payload_returns_400(self):
+        host = _register()
+        attendee = _register()
+        event_a = _create_published_event(host["id"])
+        event_b = _create_published_event(host["id"])
+        _go(attendee["id"], event_a)
+
+        token_for_a = client.get(
+            f"/attendances/me/{event_a}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        # Submit event_a's token against event_b.
+        resp = client.post(
+            f"/events/{event_b}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": token_for_a},
+        )
+        assert resp.status_code == 400
+
+    def test_non_host_returns_403(self):
+        host = _register()
+        attendee = _register()
+        other = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(other["id"]),
+            json={"token": qr_token},
+        )
+        assert resp.status_code == 403
+
+    def test_manual_checkin_by_user_id(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"user_id": attendee["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["user_id"] == attendee["id"]
+
+    def test_missing_both_fields_returns_400(self):
+        host = _register()
+        event_id = _create_published_event(host["id"])
+
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={},
+        )
+        assert resp.status_code == 400
+
+    def test_not_going_returns_404(self):
+        host = _register()
+        other = _register()
+        event_id = _create_published_event(host["id"])
+
+        # other never RSVP'd
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"user_id": other["id"]},
+        )
+        assert resp.status_code == 404
+
+    def test_unauthenticated_returns_401(self):
+        host = _register()
+        event_id = _create_published_event(host["id"])
+        resp = client.post(f"/events/{event_id}/check-in", json={"user_id": host["id"]})
+        assert resp.status_code == 401
+
+
+class TestUnGoingInvalidatesToken:
+    def test_qr_unavailable_after_un_going(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        # Un-Go
+        client.delete(f"/events/{event_id}/attendance", headers=_auth(attendee["id"]))
+
+        # The old token should now fail check-in (attendance row is gone)
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+        assert resp.status_code == 404
+
+        # And /qr should return 404 too
+        qr_resp = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        )
+        assert qr_resp.status_code == 404
+
+
+class TestAttendeeList:
+    def test_host_can_list_attendees(self):
+        host = _register()
+        a1 = _register()
+        a2 = _register()
+        event_id = _create_published_event(host["id"])
+        _go(a1["id"], event_id)
+        _go(a2["id"], event_id)
+
+        resp = client.get(f"/events/{event_id}/attendees", headers=_auth(host["id"]))
+        assert resp.status_code == 200
+        ids = {row["user_id"] for row in resp.json()}
+        assert a1["id"] in ids
+        assert a2["id"] in ids
+        # Before any check-in all checked_in_at are null
+        assert all(row["checked_in_at"] is None for row in resp.json())
+
+    def test_host_list_shows_checkin_timestamp(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+        client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+
+        resp = client.get(f"/events/{event_id}/attendees", headers=_auth(host["id"]))
+        row = next(r for r in resp.json() if r["user_id"] == attendee["id"])
+        assert row["checked_in_at"] is not None
+
+    def test_non_host_cannot_list_attendees(self):
+        host = _register()
+        other = _register()
+        event_id = _create_published_event(host["id"])
+
+        resp = client.get(f"/events/{event_id}/attendees", headers=_auth(other["id"]))
+        assert resp.status_code == 403
+
+    def test_unauthenticated_cannot_list_attendees(self):
+        host = _register()
+        event_id = _create_published_event(host["id"])
+        resp = client.get(f"/events/{event_id}/attendees")
+        assert resp.status_code == 401

--- a/backend/tests/test_checkin.py
+++ b/backend/tests/test_checkin.py
@@ -330,6 +330,108 @@ class TestUnGoingInvalidatesToken:
         assert qr_resp.status_code == 404
 
 
+class TestEventLifecycleGuards:
+    """Lock down the `event["status"] not in ("published","updated")` guard
+    in `services/attendance.check_in`. Without these tests the guard could
+    silently regress and let scans through against cancelled/ended events.
+    """
+
+    def test_check_in_blocks_cancelled_event(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        # Host cancels the event after RSVPs are in.
+        cancel = client.patch(
+            f"/events/{event_id}/status",
+            headers=_auth(host["id"]),
+            json={"status": "cancelled"},
+        )
+        assert cancel.status_code == 200
+
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+        assert resp.status_code == 400, resp.json()
+        assert "active" in resp.json()["detail"].lower()
+
+    def test_check_in_blocks_ended_event(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+        _go(attendee["id"], event_id)
+        qr_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        # Mark the event as ended directly via the status endpoint to avoid
+        # waiting on the pg_cron auto_end job.
+        end = client.patch(
+            f"/events/{event_id}/status",
+            headers=_auth(host["id"]),
+            json={"status": "ended"},
+        )
+        assert end.status_code == 200
+
+        resp = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": qr_token},
+        )
+        assert resp.status_code == 400, resp.json()
+        assert "active" in resp.json()["detail"].lower()
+
+
+class TestReGoingTokenRotation:
+    """When a user un-Goes and Goes again, a fresh token is issued and the
+    previous token must not validate. The first half is already covered by
+    `TestUnGoingInvalidatesToken`; this pins the rotation half explicitly.
+    """
+
+    def test_re_going_invalidates_old_token(self):
+        host = _register()
+        attendee = _register()
+        event_id = _create_published_event(host["id"])
+
+        # First Going + token snapshot.
+        _go(attendee["id"], event_id)
+        old_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+
+        # Un-Go → row deleted → token invalidated.
+        client.delete(f"/events/{event_id}/attendance", headers=_auth(attendee["id"]))
+
+        # Re-Go → new attendance row + new token.
+        _go(attendee["id"], event_id)
+        new_token = client.get(
+            f"/attendances/me/{event_id}/qr", headers=_auth(attendee["id"])
+        ).json()["token"]
+        assert new_token != old_token, "re-Going must rotate the token"
+
+        # Old token resolves to no row in the new attendance, so it 404s.
+        old_scan = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": old_token},
+        )
+        assert old_scan.status_code == 404, old_scan.json()
+
+        # New token works.
+        new_scan = client.post(
+            f"/events/{event_id}/check-in",
+            headers=_auth(host["id"]),
+            json={"token": new_token},
+        )
+        assert new_scan.status_code == 200, new_scan.json()
+
+
 class TestAttendeeList:
     def test_host_can_list_attendees(self):
         host = _register()

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/checkin/HostAttendeeListScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/checkin/HostAttendeeListScreen.kt
@@ -228,10 +228,16 @@ private fun formatCheckInTime(iso: String): String {
     val display = SimpleDateFormat("MMM d, HH:mm", Locale.getDefault()).apply {
         timeZone = TimeZone.getDefault()
     }
+    // Pydantic emits microseconds (6 digits, e.g. ".409953Z").
+    // Java SSS only handles 3; extra digits are mis-parsed as milliseconds and
+    // shift the displayed time by minutes. Truncate to exactly 3 digits first.
+    val normalized = iso.replace(Regex("""\.\d+""")) { m ->
+        ".${m.value.drop(1).take(3).padEnd(3, '0')}"
+    }
     val patterns = listOf("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", "yyyy-MM-dd'T'HH:mm:ssXXX")
     for (pattern in patterns) {
         try {
-            val date = SimpleDateFormat(pattern, Locale.getDefault()).parse(iso)
+            val date = SimpleDateFormat(pattern, Locale.getDefault()).parse(normalized)
             if (date != null) return display.format(date)
         } catch (_: Exception) { }
     }


### PR DESCRIPTION
Closes #232

## Summary

Full backend implementation of the QR-based check-in mechanism for issue #231.
This PR covers the **backend** (all five task-list items) and a **mobile bug fix** that surfaced during backend integration testing. The mobile feature screens (QR sheet, host scanner, attendee roster) were shipped in PR #302; this PR wires them to a real API.

---

## Backend

### Database — `sql/018_add_checkin_to_attendances.sql`

Added two columns to the `attendances` table:

| Column | Type | Notes |
|---|---|---|
| `check_in_token` | `TEXT UNIQUE` | HMAC-signed payload stored on Going |
| `checked_in_at` | `TIMESTAMPTZ` | Set on first successful scan |

A partial index on `check_in_token` (where non-null) keeps token-based lookups fast.

### Token design

Tokens are compact HMAC-SHA256 signed strings — no extra library required, no database round-trip for tamper detection:
base64url({"eid": "<event_id>", "uid": "<user_id>", "iat": <unix_ts>}).<hex_signature>




The payload encodes the `event_id` so the check-in endpoint can reject wrong-event scans before touching the database. Signature verification uses `hmac.compare_digest` for constant-time comparison. The signing key is the existing `JWT_SECRET` from `settings`.

### New endpoints

| Method | Path | Auth | Description |
|---|---|---|---|
| `GET` | `/attendances/me/{event_id}/qr` | Bearer (attendee) | Returns the signed token for the Going user. Backfills token for pre-migration rows on first call. 404 if not going. |
| `POST` | `/events/{event_id}/check-in` | Bearer (host) | Validates a scanned QR `token` **or** a manual `user_id`. Returns 400 / 403 / 404 / 409 for each error path. |
| `GET` | `/events/{event_id}/attendees` | Bearer (host) | Full Going-attendee roster with per-row `checked_in_at`. 403 for non-hosts. |

### `set_attendance` changes

When a user goes to an event a signed token is now generated and stored alongside the attendance row. On re-Going (status transition), a fresh token is issued. Idempotent calls (already going) keep the existing token unchanged. `remove_attendance` (un-Going) deletes the row entirely, which automatically invalidates the token — subsequent check-in attempts return 404.

### Files changed

| File | Change |
|---|---|
| `sql/018_add_checkin_to_attendances.sql` | New migration |
| `app/models/attendance.py` | Added `QrTokenResponse`, `CheckInRequest`, `CheckInResultResponse`, `AttendeeStatusItem` |
| `app/repositories/attendance.py` | Added `get_attendance_by_token`, `mark_checked_in`, `list_going_attendees_with_checkin`, `update_attendance_token`; extended `get_attendance` select to include new columns |
| `app/services/attendance.py` | Token generation/verification helpers; `get_my_qr`, `check_in`, `list_event_attendees` service functions; `set_attendance` updated to store token on Going |
| `app/routers/attendances.py` | `GET /attendances/me/{event_id}/qr` endpoint |
| `app/routers/events.py` | `POST /events/{event_id}/check-in` and `GET /events/{event_id}/attendees` endpoints |
| `app/main.py` | Registered the new QR sub-router |

---

## Tests — `tests/test_checkin.py` (18 integration tests)

All tests run against the live test Supabase project with real HTTP round-trips through the FastAPI app.

| Class | Test | What it verifies |
|---|---|---|
| `TestGetMyQr` | `test_qr_returned_after_going` | Going user receives a non-empty token (200) |
| | `test_qr_404_when_not_going` | Non-attendee gets 404 |
| | `test_qr_401_without_auth` | Unauthenticated caller gets 401 |
| | `test_qr_backfill_for_tokenless_attendance` | Row with NULL token gets backfilled on first GET |
| `TestCheckIn` | `test_valid_qr_scan` | Host scans valid token → 200, `checked_in_at` set |
| | `test_duplicate_scan_returns_409` | Re-scanning the same QR → 409 |
| | `test_tampered_payload_returns_400` | Last 4 chars replaced → 400 |
| | `test_wrong_event_payload_returns_400` | Event A's token submitted against Event B → 400 |
| | `test_non_host_returns_403` | Third-party user submits token → 403 |
| | `test_manual_checkin_by_user_id` | Manual `user_id` fallback → 200 |
| | `test_missing_both_fields_returns_400` | Empty body → 400 |
| | `test_not_going_returns_404` | User not RSVP'd → 404 |
| | `test_unauthenticated_returns_401` | No token → 401 |
| `TestUnGoingInvalidatesToken` | `test_qr_unavailable_after_un_going` | Delete attendance → old QR → 404; GET /qr → 404 |
| `TestAttendeeList` | `test_host_can_list_attendees` | Host sees all Going users, all `checked_in_at` null initially |
| | `test_host_list_shows_checkin_timestamp` | After check-in, timestamp appears in roster |
| | `test_non_host_cannot_list_attendees` | Non-host → 403 |
| | `test_unauthenticated_cannot_list_attendees` | No token → 401 |

CI: `test_checkin.py` added to the `media-notifications` shard in `backend-ci.yml`.

**All 18 tests pass locally against the test database.**

---

## Mobile bug fix

### `HostAttendeeListScreen.kt` — `formatCheckInTime` microsecond truncation

`AppBaseModel` serializes `datetime` fields as RFC 3339 with **6 decimal places** (microseconds), e.g. `"2026-05-06T12:21:19.496823+00:00"`. Java's `SimpleDateFormat` with the `SSS` pattern consumes all six digits and misinterprets them as milliseconds, shifting the displayed check-in time by approximately **7 minutes**.

**Fix:** before parsing, a regex normalizes the fractional-second part to exactly 3 digits so `SSS` always sees a valid millisecond value:

"...T12:21:19.496823+00:00"  →  "...T12:21:19.496+00:00"
"...T12:21:19.1+00:00"       →  "...T12:21:19.100+00:00"


The rest of the mobile API contract was verified to be fully compatible with the backend:
- All three endpoint URLs match the `ApiService.kt` annotations exactly
- All DTO field names match the backend response schemas
- HTTP status codes 400 / 403 / 404 / 409 align with `CheckInOutcome` in `CheckInRepository`
- Gson's default null-field omission is compatible with Pydantic's optional fields
- UUID values serialized by Pydantic as strings are correctly received as `String` in Kotlin

---

## Notes

- The SQL migration (`018_add_checkin_to_attendances.sql`) must be applied to the **production** Supabase project on deploy. It uses `ADD COLUMN IF NOT EXISTS` so it is safe to re-run.
- Existing `going` attendance rows without a token are handled by the backfill path in `get_my_qr` — no data migration is needed.


