### PR TITLE
feat(web): similar events section on event detail (#282)

### DIFF
--- a/frontend/src/app/event/[id]/page.tsx
+++ b/frontend/src/app/event/[id]/page.tsx
@@ -35,6 +35,7 @@ import { Navbar } from "@/components/layout/navbar";
 import { StatusBadge, eventStatusVariant } from "@/components/event/status-badge";
 import { ImageCarousel } from "@/components/event/image-carousel";
 import { CommentSection } from "@/components/event/comment-section";
+import { SimilarEventsSection } from "@/components/event/similar-events";
 import { ConfirmDialog } from "@/components/event/confirm-dialog";
 import { AttendeeAvatarStack } from "@/components/event/attendee-avatar-stack";
 import { LocationMapModal } from "@/components/event/location-map-modal";
@@ -873,6 +874,9 @@ function FullView({
                 Comments are closed for cancelled events.
               </div>
             )}
+
+            {/* Similar events — backend filters out source event, cancelled, ended, and inaccessible private events. */}
+            <SimilarEventsSection eventId={event.id} />
           </div>
         </div>
         {/* close relative wrapper for left column */}

--- a/frontend/src/components/event/similar-events.tsx
+++ b/frontend/src/components/event/similar-events.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+
+import { fetchSimilarEvents, type EventListItem } from "@/lib/events-api";
+import { cn } from "@/lib/utils";
+
+interface SimilarEventsSectionProps {
+  eventId: string;
+}
+
+function formatShortDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const date = d.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+  const time = d.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return `${date} · ${time}`;
+}
+
+export function SimilarEventsSection({ eventId }: SimilarEventsSectionProps) {
+  const [events, setEvents] = useState<EventListItem[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSimilarEvents(eventId)
+      .then((items) => {
+        if (!cancelled) setEvents(items);
+      })
+      .catch(() => {
+        if (!cancelled) setEvents([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventId]);
+
+  if (!loading && (!events || events.length === 0)) return null;
+
+  return (
+    <section className="mt-8" aria-labelledby="similar-events-heading">
+      <h3
+        id="similar-events-heading"
+        className="font-heading text-brand-dark mb-3 text-lg font-semibold"
+      >
+        Similar events
+      </h3>
+
+      {loading ? (
+        <div
+          className="border-brand-mid-alpha flex h-32 items-center justify-center rounded-xl border bg-white"
+          role="status"
+          aria-label="Loading similar events"
+        >
+          <Loader2 className="text-brand-mid size-5 animate-spin" />
+        </div>
+      ) : (
+        <ul
+          className="-mx-1 flex snap-x gap-3 overflow-x-auto px-1 pb-2 [scrollbar-width:thin]"
+          role="list"
+        >
+          {events!.map((event) => (
+            <li key={event.id} className="snap-start">
+              <SimilarEventCard event={event} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+interface SimilarEventCardProps {
+  event: EventListItem;
+}
+
+function SimilarEventCard({ event }: SimilarEventCardProps) {
+  const primaryCategory = event.categories[0]?.name;
+  const locationName = event.primary_location?.name;
+  const [imageBroken, setImageBroken] = useState(false);
+  const showImage = !!event.primary_image_url && !imageBroken;
+
+  return (
+    <Link
+      href={`/event/${event.id}`}
+      className={cn(
+        "border-brand-mid-alpha hover:border-brand-mid focus-visible:ring-brand-dark group relative block w-[200px] shrink-0 overflow-hidden rounded-xl border bg-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+      )}
+      aria-label={`Similar event: ${event.title}`}
+    >
+      <div className="bg-brand-mid/20 relative h-24 w-full overflow-hidden">
+        {showImage ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={event.primary_image_url!}
+            alt=""
+            className="size-full object-cover transition-transform duration-300 group-hover:scale-105"
+            loading="lazy"
+            onError={() => setImageBroken(true)}
+          />
+        ) : (
+          <div className="bg-brand-surface flex size-full items-center justify-center">
+            <span className="text-brand-mid font-serif text-xs uppercase tracking-wider">
+              No image
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="space-y-1 p-3">
+        <p className="text-brand-dark line-clamp-2 text-sm font-semibold leading-tight">
+          {event.title}
+        </p>
+        <p className="text-brand-mid text-xs">{formatShortDate(event.start_datetime)}</p>
+        {primaryCategory ? (
+          <p className="text-brand-mid truncate text-xs">{primaryCategory}</p>
+        ) : locationName ? (
+          <p className="text-brand-mid truncate text-xs">{locationName}</p>
+        ) : null}
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/components/event/similar-events.tsx
+++ b/frontend/src/components/event/similar-events.tsx
@@ -112,14 +112,14 @@ function SimilarEventCard({ event }: SimilarEventCardProps) {
           />
         ) : (
           <div className="bg-brand-surface flex size-full items-center justify-center">
-            <span className="text-brand-mid font-serif text-xs uppercase tracking-wider">
+            <span className="text-brand-mid font-serif text-xs tracking-wider uppercase">
               No image
             </span>
           </div>
         )}
       </div>
       <div className="space-y-1 p-3">
-        <p className="text-brand-dark line-clamp-2 text-sm font-semibold leading-tight">
+        <p className="text-brand-dark line-clamp-2 text-sm leading-tight font-semibold">
           {event.title}
         </p>
         <p className="text-brand-mid text-xs">{formatShortDate(event.start_datetime)}</p>

--- a/frontend/src/lib/events-api.ts
+++ b/frontend/src/lib/events-api.ts
@@ -361,6 +361,10 @@ export async function fetchComments(eventId: string): Promise<CommentListRespons
   return apiRequest<CommentListResponse>(`/events/${eventId}/comments`);
 }
 
+export async function fetchSimilarEvents(eventId: string): Promise<EventListItem[]> {
+  return apiRequest<EventListItem[]>(`/events/${eventId}/similar`, { auth: "optional" });
+}
+
 export async function postComment(
   eventId: string,
   content: string,

--- a/frontend/tests/events-api.test.ts
+++ b/frontend/tests/events-api.test.ts
@@ -9,6 +9,7 @@ import {
   fetchEventDetail,
   fetchHostProfile,
   fetchNotifications,
+  fetchSimilarEvents,
   markAllNotificationsRead,
   markNotificationRead,
   postComment,
@@ -124,6 +125,15 @@ describe("events-api endpoints", () => {
     await fetchComments(EVENT_ID);
     const { url } = lastCall(fetchMock);
     expect(url).toContain(`/events/${EVENT_ID}/comments`);
+  });
+
+  it("fetchSimilarEvents GETs /events/{id}/similar with optional auth", async () => {
+    fetchMock.mockImplementationOnce(() => Promise.resolve(jsonOk([])));
+    const result = await fetchSimilarEvents(EVENT_ID);
+    const { url, init } = lastCall(fetchMock);
+    expect(url).toContain(`/events/${EVENT_ID}/similar`);
+    expect(init.method ?? "GET").toBe("GET");
+    expect(result).toEqual([]);
   });
 
   it("postComment POSTs the text and forwards parent_id when given", async () => {

--- a/frontend/tests/similar-events.test.tsx
+++ b/frontend/tests/similar-events.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SimilarEventsSection } from "@/components/event/similar-events";
+import type * as EventsApiModule from "@/lib/events-api";
+import type { EventListItem } from "@/lib/events-api";
+
+const { fetchSimilarEventsMock } = vi.hoisted(() => ({
+  fetchSimilarEventsMock: vi.fn<typeof EventsApiModule.fetchSimilarEvents>(),
+}));
+
+vi.mock("@/lib/events-api", async () => {
+  const actual = await vi.importActual<typeof EventsApiModule>("@/lib/events-api");
+  return { ...actual, fetchSimilarEvents: fetchSimilarEventsMock };
+});
+
+function makeEvent(overrides: Partial<EventListItem> = {}): EventListItem {
+  return {
+    id: "ev-similar-1",
+    host_id: "host-1",
+    title: "Galata Tower Sunset Walk",
+    description: null,
+    start_datetime: "2026-07-04T18:00:00Z",
+    end_datetime: "2026-07-04T20:00:00Z",
+    visibility: "public",
+    is_age_restricted: false,
+    attendee_limit: 30,
+    attendee_count: 4,
+    status: "published",
+    is_bookmarked: null,
+    attendance_status: null,
+    access_request_status: null,
+    has_access: null,
+    going_count: 4,
+    bookmark_count: 2,
+    is_full: false,
+    categories: [{ id: "c-1", name: "Outdoor", is_predefined: true, is_approved: true }],
+    primary_location: null,
+    primary_image_url: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  fetchSimilarEventsMock.mockReset();
+});
+
+describe("SimilarEventsSection", () => {
+  beforeEach(() => {
+    fetchSimilarEventsMock.mockResolvedValue([]);
+  });
+
+  it("renders nothing once an empty list resolves", async () => {
+    fetchSimilarEventsMock.mockResolvedValueOnce([]);
+    const { container } = render(<SimilarEventsSection eventId="src-event" />);
+    await waitFor(() => expect(container.querySelector("section")).toBeNull());
+  });
+
+  it("hides the section when the request fails", async () => {
+    fetchSimilarEventsMock.mockRejectedValueOnce(new Error("boom"));
+    const { container } = render(<SimilarEventsSection eventId="src-event" />);
+    await waitFor(() => expect(container.querySelector("section")).toBeNull());
+  });
+
+  it("renders a card per similar event with the correct detail link", async () => {
+    fetchSimilarEventsMock.mockResolvedValueOnce([
+      makeEvent({ id: "a", title: "Alpha event" }),
+      makeEvent({ id: "b", title: "Beta event" }),
+    ]);
+    render(<SimilarEventsSection eventId="src-event" />);
+
+    expect(await screen.findByRole("heading", { name: /similar events/i })).toBeInTheDocument();
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/event/a");
+    expect(links[1]).toHaveAttribute("href", "/event/b");
+    expect(screen.getByText("Alpha event")).toBeInTheDocument();
+    expect(screen.getByText("Beta event")).toBeInTheDocument();
+  });
+
+  it("shows the primary category when present, otherwise the location name", async () => {
+    fetchSimilarEventsMock.mockResolvedValueOnce([
+      makeEvent({
+        id: "with-cat",
+        title: "With category",
+        categories: [{ id: "c-1", name: "Music", is_predefined: true, is_approved: true }],
+      }),
+      makeEvent({
+        id: "no-cat",
+        title: "No category",
+        categories: [],
+        primary_location: {
+          id: "loc-1",
+          name: "Karaköy",
+          latitude: 41.0,
+          longitude: 28.9,
+          is_primary: true,
+          order_index: 0,
+        },
+      }),
+    ]);
+    render(<SimilarEventsSection eventId="src-event" />);
+
+    expect(await screen.findByText("Music")).toBeInTheDocument();
+    expect(screen.getByText("Karaköy")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #282

## Summary
- Adds a horizontally scrollable **Similar events** section beneath the comments on the event detail page, mirroring the mobile UI shipped in #294.
- Uses the existing `GET /events/{event_id}/similar` endpoint (optional auth, max 5 ranked candidates) and reuses the `EventListItem` shape.
- Section is rendered only inside `FullView` so it follows the same lifecycle as mobile (only fires when the full detail loads successfully). Limited / private-no-access detail views are unaffected.

## Behaviour
- **Empty / error** — section is hidden entirely after the request resolves; no empty header.
- **Loading** — heading + spinner box visible while fetching.
- **Card** — image (with graceful fallback for broken/missing URLs), 2-line ellipsised title, formatted date with time (\`Mon, Jun 1 · 09:00\`), and primary category (falls back to primary location name when there is no category).
- **Click** — each card links to \`/event/{id}\`; navigating between similar events refetches automatically via the \`eventId\` effect dep.
- **Guest** — backend treats auth as optional, so unauthenticated users see the same preview cards as on Discovery.

## Files
- \`frontend/src/lib/events-api.ts\` — new \`fetchSimilarEvents()\` wrapper.
- \`frontend/src/components/event/similar-events.tsx\` — new \`SimilarEventsSection\` + slim card.
- \`frontend/src/app/event/[id]/page.tsx\` — renders the section beneath comments inside \`FullView\`.
- \`frontend/tests/events-api.test.ts\` — endpoint wiring test.
- \`frontend/tests/similar-events.test.tsx\` — RTL coverage for empty, error, render, and category/location fallback.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [x] \`npx vitest run\` — 91 / 91 tests pass
- [x] Manual Playwright run against the local backend: 5 cards render, broken image swaps to "NO IMAGE" placeholder, click navigates to detail and the destination event refetches its own similar list.