### PR TITLE
feat(web): render event_recommended notifications (#279)

### DIFF
--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -12,6 +12,7 @@ import {
   ChevronRight,
   Loader2,
   MessageSquare,
+  Sparkles,
   UserPlus,
   XCircle,
 } from "lucide-react";
@@ -49,7 +50,7 @@ function formatTimeAgo(dateStr: string): string {
   });
 }
 
-function getNotificationIcon(type: string, isRead: boolean) {
+export function getNotificationIcon(type: string, isRead: boolean) {
   const baseClass = "size-[18px]";
 
   switch (type) {
@@ -84,6 +85,12 @@ function getNotificationIcon(type: string, isRead: boolean) {
         bg: isRead ? "bg-brand-dark/20" : "bg-brand-dark",
         fg: isRead ? "text-brand-dark" : "text-white",
       };
+    case "event_recommended":
+      return {
+        icon: <Sparkles className={baseClass} />,
+        bg: isRead ? "bg-brand-dark/15" : "bg-brand-dark",
+        fg: isRead ? "text-brand-dark/70" : "text-white",
+      };
     default:
       return {
         icon: <Bell className={baseClass} />,
@@ -93,7 +100,7 @@ function getNotificationIcon(type: string, isRead: boolean) {
   }
 }
 
-function NotificationItem({
+export function NotificationItem({
   notification,
   onMarkRead,
 }: {
@@ -128,6 +135,11 @@ function NotificationItem({
 
       {/* Content */}
       <div className="min-w-0 flex-1">
+        {notification.type === "event_recommended" && (
+          <span className="bg-brand-surface text-brand-dark mb-1.5 inline-flex items-center rounded-md px-1.5 py-[1px] text-[10px] font-semibold tracking-wide uppercase">
+            Recommended for you
+          </span>
+        )}
         <p
           className={cn(
             "text-brand-dark text-sm leading-tight",

--- a/frontend/tests/inbox-event-recommended.test.tsx
+++ b/frontend/tests/inbox-event-recommended.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationItem, getNotificationIcon } from "@/app/inbox/page";
+import type { Notification } from "@/lib/events-api";
+
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn<(href: string) => void>() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: "n-1",
+    user_id: "u-1",
+    event_id: "ev-42",
+    type: "event_recommended",
+    message: "Based on events you attended in Music",
+    is_read: false,
+    created_at: "2026-05-09T10:00:00Z",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  pushMock.mockReset();
+});
+
+describe("getNotificationIcon", () => {
+  it("returns the Sparkles-decorated styling for event_recommended", () => {
+    const unread = getNotificationIcon("event_recommended", false);
+    expect(unread.bg).toBe("bg-brand-dark");
+    expect(unread.fg).toBe("text-white");
+
+    const read = getNotificationIcon("event_recommended", true);
+    expect(read.bg).toContain("brand-dark");
+    expect(read.fg).toContain("brand-dark");
+  });
+
+  it("falls back to the bell icon for unknown types", () => {
+    const fallback = getNotificationIcon("totally_made_up_type", false);
+    expect(fallback.bg).toContain("brand-mid");
+  });
+});
+
+describe("NotificationItem", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+  });
+
+  it("renders the 'Recommended for you' pill for event_recommended", () => {
+    render(<NotificationItem notification={makeNotification()} onMarkRead={vi.fn()} />);
+    expect(screen.getByText(/recommended for you/i)).toBeInTheDocument();
+    expect(screen.getByText("Based on events you attended in Music")).toBeInTheDocument();
+  });
+
+  it("does NOT render the pill for non-recommendation notification types", () => {
+    render(
+      <NotificationItem
+        notification={makeNotification({ type: "event_updated", message: "Event updated" })}
+        onMarkRead={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/recommended for you/i)).toBeNull();
+    expect(screen.getByText("Event updated")).toBeInTheDocument();
+  });
+
+  it("marks the notification as read and navigates to the event on click", () => {
+    const onMarkRead = vi.fn();
+    render(<NotificationItem notification={makeNotification()} onMarkRead={onMarkRead} />);
+    screen.getByText("Based on events you attended in Music").click();
+    expect(onMarkRead).toHaveBeenCalledWith("n-1");
+    expect(pushMock).toHaveBeenCalledWith("/event/ev-42");
+  });
+
+  it("skips navigation when event_id is null but still marks as read", () => {
+    const onMarkRead = vi.fn();
+    render(
+      <NotificationItem
+        notification={makeNotification({ event_id: null })}
+        onMarkRead={onMarkRead}
+      />,
+    );
+    screen.getByText("Based on events you attended in Music").click();
+    expect(onMarkRead).toHaveBeenCalledWith("n-1");
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #279

## Summary
- Mirrors the mobile rendering shipped in #303 — backend (#298) emits \`event_recommended\` notifications, but the web inbox was rendering them with the generic Bell fallback and no visual cue.
- Maps \`event_recommended\` → Sparkles icon with brand-dark tint (read/unread alpha kept consistent with the existing styling rules).
- Adds a small *"Recommended for you"* pill above the message body, type-gated so other notification types are untouched.

## Behaviour
- Tap-to-open + mark-as-read already route through the type-agnostic click handler in \`NotificationItem\` and the existing event-id navigation, so no wiring changes are needed.
- Bell badge polling and \`unread_count\` are type-agnostic, so the new type lights up the navbar bell automatically.
- Notifications without an \`event_id\` (e.g. if the source event was deleted between emission and tap) still render the pill but do not navigate, matching the existing fallback.

## Files
- \`frontend/src/app/inbox/page.tsx\` — Sparkles icon mapping, "Recommended for you" pill, and minor exports for testability.
- \`frontend/tests/inbox-event-recommended.test.tsx\` — 6 new tests covering icon mapping, pill gating, click-to-navigate, and the no-event_id fallback.

## Test plan
- [x] \`npm run check\` (format + lint:ci + typecheck + tests) — 92 / 92 tests pass locally
- [x] Pill renders only for \`event_recommended\`; existing types unchanged
- [x] Sparkles icon shown with read/unread variant styling
- [x] Click on a recommendation marks it read and navigates to the event detail