### PR TITLE
Feat/web/going events profile

### DIFF
--- a/frontend/src/components/profile/my-profile-page.tsx
+++ b/frontend/src/components/profile/my-profile-page.tsx
@@ -40,6 +40,7 @@ import {
   type ProfileUpdatePayload,
   type ProfileVisibility,
 } from "@/lib/api";
+import { fetchMyGoingEvents, type EventListItem } from "@/lib/events-api";
 import {
   CREATE_EVENT_PAGE_PATH,
   getEditEventPagePath,
@@ -50,7 +51,8 @@ import { cn } from "@/lib/utils";
 
 const BOOKMARKS_PAGE_SIZE = 6;
 type MyEventsTab = "draft" | "past" | "upcoming";
-type ProfileSection = "my-events" | "saved-events" | "settings";
+type GoingTab = "upcoming" | "past";
+type ProfileSection = "going-events" | "my-events" | "saved-events" | "settings";
 
 interface ProfileFormState {
   dateOfBirth: string;
@@ -184,6 +186,69 @@ function myEventStatusChip(event: HostedEventSummary) {
     className: "border border-emerald-200 bg-emerald-100 text-emerald-700",
     label: "Live",
   };
+}
+
+function GoingEventCard({ event }: { event: EventListItem }) {
+  const isPast =
+    event.status === "cancelled" ||
+    event.status === "ended" ||
+    new Date(event.end_datetime).getTime() < Date.now();
+
+  return (
+    <Link
+      href={`/event/${event.id}`}
+      className="group border-brand-mid/12 overflow-hidden rounded-[24px] border bg-white shadow-[0_20px_54px_-42px_rgba(73,54,40,0.55)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_26px_66px_-40px_rgba(73,54,40,0.6)]"
+    >
+      <div className="bg-brand-mid/20 relative h-44 overflow-hidden">
+        {event.primary_image_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={event.primary_image_url}
+            alt={event.title}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-[linear-gradient(135deg,rgba(73,54,40,0.9),rgba(171,136,109,0.7))]">
+            <CalendarDays className="size-10 text-white/45" />
+          </div>
+        )}
+        <div className="absolute inset-x-0 top-0 flex items-start justify-between gap-2 p-4">
+          <span
+            className={cn(
+              "rounded-full px-3 py-1 text-[11px] font-bold tracking-[0.14em] uppercase",
+              isPast
+                ? "border-brand-mid/15 bg-brand-bg text-brand-mid border"
+                : "border border-emerald-200 bg-emerald-100 text-emerald-700",
+            )}
+          >
+            {isPast ? "Attended" : "Going"}
+          </span>
+        </div>
+      </div>
+
+      <div className="space-y-3 p-5">
+        <div className="flex flex-wrap gap-2">
+          {event.categories.slice(0, 3).map((category) => (
+            <span
+              key={category.id}
+              className="bg-brand-bg text-brand-mid rounded-full px-3 py-1 text-[11px] font-semibold"
+            >
+              {category.name}
+            </span>
+          ))}
+        </div>
+        <div>
+          <h3 className="font-heading text-brand-dark text-xl font-semibold">{event.title}</h3>
+          <p className="text-brand-mid mt-1 text-sm font-medium">
+            {formatDateTime(event.start_datetime)}
+          </p>
+        </div>
+        <p className="text-brand-mid text-xs">
+          {event.primary_location ? event.primary_location.name : "Location not set"}
+        </p>
+      </div>
+    </Link>
+  );
 }
 
 function BookmarkedEventCard({ event }: { event: BookmarkedEventSummary }) {
@@ -411,13 +476,17 @@ export function MyProfilePage() {
   const [profileError, setProfileError] = useState<string | null>(null);
   const [bookmarks, setBookmarks] = useState<BookmarkListResponse | null>(null);
   const [hostProfile, setHostProfile] = useState<HostProfileSummaryResponse | null>(null);
+  const [goingEvents, setGoingEvents] = useState<EventListItem[]>([]);
   const [bookmarksLoading, setBookmarksLoading] = useState(true);
   const [bookmarksError, setBookmarksError] = useState<string | null>(null);
   const [hostProfileLoading, setHostProfileLoading] = useState(true);
   const [hostProfileError, setHostProfileError] = useState<string | null>(null);
+  const [goingEventsLoading, setGoingEventsLoading] = useState(true);
+  const [goingEventsError, setGoingEventsError] = useState<string | null>(null);
   const [bookmarkPage, setBookmarkPage] = useState(1);
   const [activeSection, setActiveSection] = useState<ProfileSection>("settings");
   const [eventsTab, setEventsTab] = useState<MyEventsTab>("upcoming");
+  const [goingTab, setGoingTab] = useState<GoingTab>("upcoming");
   const [cancellingEventId, setCancellingEventId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -517,6 +586,37 @@ export function MyProfilePage() {
     };
   }, [bookmarkPage, isInitialized, status]);
 
+  useEffect(() => {
+    if (!isInitialized || status !== "authenticated") {
+      return;
+    }
+
+    let active = true;
+
+    void fetchMyGoingEvents()
+      .then((events) => {
+        if (!active) {
+          return;
+        }
+
+        setGoingEvents(events);
+        setGoingEventsError(null);
+        setGoingEventsLoading(false);
+      })
+      .catch((error: unknown) => {
+        if (!active) {
+          return;
+        }
+
+        setGoingEventsError(getErrorMessage(error, "We could not load your going events."));
+        setGoingEventsLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [isInitialized, status]);
+
   function updateForm<K extends keyof ProfileFormState>(key: K, value: ProfileFormState[K]) {
     setForm((current) => (current ? { ...current, [key]: value } : current));
     setSaveError(null);
@@ -610,6 +710,20 @@ export function MyProfilePage() {
       setCancellingEventId(null);
     }
   }
+
+  const upcomingGoingEvents = goingEvents.filter(
+    (event) =>
+      event.status !== "cancelled" &&
+      event.status !== "ended" &&
+      new Date(event.end_datetime).getTime() >= Date.now(),
+  );
+  const pastGoingEvents = goingEvents.filter(
+    (event) =>
+      event.status === "cancelled" ||
+      event.status === "ended" ||
+      new Date(event.end_datetime).getTime() < Date.now(),
+  );
+  const visibleGoingEvents = goingTab === "upcoming" ? upcomingGoingEvents : pastGoingEvents;
 
   const hostedEvents = hostProfile?.hosted_events ?? [];
   const draftHostedEvents = hostedEvents.filter((event) => event.status === "draft");
@@ -728,6 +842,12 @@ export function MyProfilePage() {
                       icon: CalendarDays,
                       key: "my-events",
                       label: "My Events",
+                    },
+                    {
+                      description: "Going & attended",
+                      icon: Users,
+                      key: "going-events",
+                      label: "Going Events",
                     },
                     {
                       description: "Bookmarked events",
@@ -896,6 +1016,99 @@ export function MyProfilePage() {
                   </Card>
                 </section>
               </div>
+            ) : null}
+
+            {activeSection === "going-events" ? (
+              <section className="space-y-6">
+                <div>
+                  <h2 className="font-heading text-brand-dark text-3xl font-bold">Going Events</h2>
+                  <p className="text-brand-mid mt-1 text-sm">
+                    Events you&apos;ve marked as going or already attended.
+                  </p>
+                </div>
+
+                <div className="border-brand-mid/15 overflow-x-auto border-b">
+                  <div className="flex min-w-max gap-0">
+                    {(
+                      [
+                        { key: "upcoming", label: "Upcoming", count: upcomingGoingEvents.length },
+                        { key: "past", label: "Past / Attended", count: pastGoingEvents.length },
+                      ] as const
+                    ).map((tab) => (
+                      <button
+                        key={tab.key}
+                        type="button"
+                        onClick={() => setGoingTab(tab.key)}
+                        className={cn(
+                          "inline-flex cursor-pointer items-center gap-2 border-b-[3px] px-6 py-3 text-sm transition-colors",
+                          goingTab === tab.key
+                            ? "border-brand-dark text-brand-dark font-bold"
+                            : "text-brand-mid hover:text-brand-dark border-transparent font-medium",
+                        )}
+                      >
+                        {tab.label}
+                        <span
+                          className={cn(
+                            "rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
+                            goingTab === tab.key
+                              ? "bg-brand-dark text-white"
+                              : "bg-brand-surface text-brand-mid",
+                          )}
+                        >
+                          {tab.count}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {goingEventsError ? (
+                  <div className="rounded-[20px] border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    {goingEventsError}
+                  </div>
+                ) : goingEventsLoading ? (
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                      <div
+                        key={index}
+                        className="border-brand-mid/12 overflow-hidden rounded-[24px] border bg-white"
+                      >
+                        <div className="bg-brand-mid/15 h-44 animate-pulse" />
+                        <div className="space-y-3 p-5">
+                          <div className="bg-brand-mid/12 h-4 animate-pulse rounded-full" />
+                          <div className="bg-brand-mid/10 h-4 w-2/3 animate-pulse rounded-full" />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : visibleGoingEvents.length > 0 ? (
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {visibleGoingEvents.map((event) => (
+                      <GoingEventCard key={event.id} event={event} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="border-brand-mid/12 bg-brand-bg/75 rounded-[24px] border px-6 py-12 text-center">
+                    <div className="bg-brand-mid/12 text-brand-mid mx-auto flex size-16 items-center justify-center rounded-full">
+                      <Users className="size-7" />
+                    </div>
+                    <p className="font-heading text-brand-dark mt-4 text-2xl">
+                      {goingTab === "upcoming" ? "No upcoming events" : "No attended events yet"}
+                    </p>
+                    <p className="text-brand-mid mt-2 text-sm">
+                      {goingTab === "upcoming"
+                        ? "Mark events as going from the discovery page to see them here."
+                        : "Events you attended will appear here after they end."}
+                    </p>
+                    <Button
+                      asChild
+                      className="bg-brand-dark hover:bg-brand-dark/85 mt-5 border-0 text-white"
+                    >
+                      <Link href="/">Explore Events</Link>
+                    </Button>
+                  </div>
+                )}
+              </section>
             ) : null}
 
             {activeSection === "saved-events" ? (

--- a/frontend/src/components/profile/my-profile-page.tsx
+++ b/frontend/src/components/profile/my-profile-page.tsx
@@ -188,12 +188,7 @@ function myEventStatusChip(event: HostedEventSummary) {
   };
 }
 
-function GoingEventCard({ event }: { event: EventListItem }) {
-  const isPast =
-    event.status === "cancelled" ||
-    event.status === "ended" ||
-    new Date(event.end_datetime).getTime() < Date.now();
-
+function GoingEventCard({ event, isPast }: { event: EventListItem; isPast: boolean }) {
   return (
     <Link
       href={`/event/${event.id}`}
@@ -1084,7 +1079,7 @@ export function MyProfilePage() {
                 ) : visibleGoingEvents.length > 0 ? (
                   <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                     {visibleGoingEvents.map((event) => (
-                      <GoingEventCard key={event.id} event={event} />
+                      <GoingEventCard key={event.id} event={event} isPast={goingTab === "past"} />
                     ))}
                   </div>
                 ) : (

--- a/frontend/src/lib/events-api.ts
+++ b/frontend/src/lib/events-api.ts
@@ -434,6 +434,10 @@ export async function fetchSimilarEvents(eventId: string): Promise<EventListItem
   return apiRequest<EventListItem[]>(`/events/${eventId}/similar`, { auth: "optional" });
 }
 
+export async function fetchMyGoingEvents(): Promise<EventListItem[]> {
+  return apiRequest<EventListItem[]>(`/attendances/me/events`, { auth: "required" });
+}
+
 export async function postComment(
   eventId: string,
   content: string,

--- a/frontend/tests/going-events-api.test.ts
+++ b/frontend/tests/going-events-api.test.ts
@@ -40,7 +40,14 @@ function makeEventListItem(overrides: Record<string, unknown> = {}) {
     bookmark_count: 1,
     is_full: false,
     categories: [{ id: "c-1", name: "Sport", is_predefined: true, is_approved: true }],
-    primary_location: { id: "loc-1", name: "Central Park", latitude: 40.78, longitude: -73.96, is_primary: true, order_index: 0 },
+    primary_location: {
+      id: "loc-1",
+      name: "Central Park",
+      latitude: 40.78,
+      longitude: -73.96,
+      is_primary: true,
+      order_index: 0,
+    },
     primary_image_url: null,
     ...overrides,
   };

--- a/frontend/tests/going-events-api.test.ts
+++ b/frontend/tests/going-events-api.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchMyGoingEvents } from "@/lib/events-api";
+import { setAuthenticatedSession } from "@/lib/session";
+
+const USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+
+function jsonOk(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function lastCall(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) throw new Error("fetch was not called");
+  const [url, init] = call as [string, RequestInit];
+  return { url: String(url), init };
+}
+
+function makeEventListItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "ev-1",
+    host_id: "host-1",
+    title: "Yoga in the Park",
+    description: null,
+    start_datetime: "2026-07-10T09:00:00Z",
+    end_datetime: "2026-07-10T10:00:00Z",
+    visibility: "public",
+    is_age_restricted: false,
+    attendee_limit: 20,
+    attendee_count: 5,
+    status: "published",
+    is_bookmarked: null,
+    attendance_status: "going",
+    access_request_status: null,
+    has_access: null,
+    going_count: 5,
+    bookmark_count: 1,
+    is_full: false,
+    categories: [{ id: "c-1", name: "Sport", is_predefined: true, is_approved: true }],
+    primary_location: { id: "loc-1", name: "Central Park", latitude: 40.78, longitude: -73.96, is_primary: true, order_index: 0 },
+    primary_image_url: null,
+    ...overrides,
+  };
+}
+
+describe("fetchMyGoingEvents", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    setAuthenticatedSession({
+      access_token: "test-token",
+      token_type: "bearer",
+      user: {
+        id: USER_ID,
+        username: "testuser",
+        email: "test@example.com",
+        phone_number: null,
+        date_of_birth: null,
+        email_visibility: false,
+        phone_visibility: false,
+        role: "registered",
+        auth_provider: "local",
+        email_verified: true,
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("GETs /attendances/me/events with the auth header", async () => {
+    fetchMock.mockResolvedValueOnce(jsonOk([]));
+    await fetchMyGoingEvents();
+    const { url, init } = lastCall(fetchMock);
+    expect(url).toContain("/attendances/me/events");
+    expect(init.method ?? "GET").toBe("GET");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer test-token");
+  });
+
+  it("returns the parsed list of going events", async () => {
+    const events = [
+      makeEventListItem({ id: "ev-1", title: "Yoga in the Park" }),
+      makeEventListItem({ id: "ev-2", title: "Evening Run" }),
+    ];
+    fetchMock.mockResolvedValueOnce(jsonOk(events));
+    const result = await fetchMyGoingEvents();
+    expect(result).toHaveLength(2);
+    expect(result[0].title).toBe("Yoga in the Park");
+    expect(result[1].title).toBe("Evening Run");
+  });
+
+  it("returns an empty array when the user has no going events", async () => {
+    fetchMock.mockResolvedValueOnce(jsonOk([]));
+    const result = await fetchMyGoingEvents();
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/tests/going-events-profile.test.tsx
+++ b/frontend/tests/going-events-profile.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -206,7 +206,9 @@ describe("Going Events tab — past sub-tab", () => {
     await userEvent.click(pastTab);
 
     expect(await screen.findByText("Beach Volleyball")).toBeInTheDocument();
-    expect(screen.getByText(/attended/i)).toBeInTheDocument();
+    // "Attended" appears in both the tab label ("Past / Attended") and the badge
+    const attendedMatches = screen.getAllByText(/attended/i);
+    expect(attendedMatches.length).toBeGreaterThanOrEqual(2);
   });
 
   it("shows the empty state when there are no attended events", async () => {
@@ -222,7 +224,8 @@ describe("Going Events tab — past sub-tab", () => {
 
 describe("Going Events tab — error state", () => {
   it("shows an error message when the fetch fails", async () => {
-    fetchMyGoingEventsMock.mockRejectedValue(new Error("Network error"));
+    // Reject with a non-Error so getErrorMessage falls back to the user-friendly string
+    fetchMyGoingEventsMock.mockRejectedValue("Network error");
     await renderProfileAndOpenGoingTab();
 
     expect(await screen.findByText(/we could not load your going events/i)).toBeInTheDocument();

--- a/frontend/tests/going-events-profile.test.tsx
+++ b/frontend/tests/going-events-profile.test.tsx
@@ -1,0 +1,231 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as EventsApiModule from "@/lib/events-api";
+import type { EventListItem } from "@/lib/events-api";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+const { fetchMyGoingEventsMock } = vi.hoisted(() => ({
+  fetchMyGoingEventsMock: vi.fn<typeof EventsApiModule.fetchMyGoingEvents>(),
+}));
+
+vi.mock("@/lib/events-api", async () => {
+  const actual = await vi.importActual<typeof EventsApiModule>("@/lib/events-api");
+  return { ...actual, fetchMyGoingEvents: fetchMyGoingEventsMock };
+});
+
+// next/navigation
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useParams: () => ({}),
+  usePathname: () => "/profile",
+}));
+
+// Auth — authenticated user
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    isInitialized: true,
+    status: "authenticated",
+    user: {
+      id: "user-1",
+      username: "testuser",
+      email: "test@example.com",
+      phone_number: null,
+      date_of_birth: null,
+      email_visibility: false,
+      phone_visibility: false,
+      role: "registered",
+      auth_provider: "local",
+      email_verified: true,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  }),
+}));
+
+// Stub out the other API calls the page makes so they don't interfere
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@/lib/api");
+  return {
+    ...actual,
+    getCurrentUser: vi.fn().mockResolvedValue({
+      id: "user-1",
+      username: "testuser",
+      email: "test@example.com",
+      phone_number: null,
+      date_of_birth: null,
+      email_visibility: false,
+      phone_visibility: false,
+      role: "registered",
+      auth_provider: "local",
+      email_verified: true,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    }),
+    getHostProfileSummary: vi.fn().mockResolvedValue({
+      id: "user-1",
+      username: "testuser",
+      average_rating: null,
+      hosted_events: [],
+      hosted_events_count: 0,
+    }),
+    getMyBookmarks: vi.fn().mockResolvedValue({ items: [], total: 0, total_pages: 0 }),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<EventListItem> = {}): EventListItem {
+  return {
+    id: "ev-1",
+    host_id: "host-1",
+    title: "Sunset Yoga",
+    description: null,
+    start_datetime: "2099-08-01T17:00:00Z",
+    end_datetime: "2099-08-01T18:00:00Z",
+    visibility: "public",
+    is_age_restricted: false,
+    attendee_limit: 20,
+    attendee_count: 5,
+    status: "published",
+    is_bookmarked: null,
+    attendance_status: "going",
+    access_request_status: null,
+    has_access: null,
+    going_count: 5,
+    bookmark_count: 1,
+    is_full: false,
+    categories: [{ id: "c-1", name: "Wellness", is_predefined: true, is_approved: true }],
+    primary_location: null,
+    primary_image_url: null,
+    ...overrides,
+  };
+}
+
+async function renderProfileAndOpenGoingTab() {
+  // Lazy import so mocks are registered first
+  const { MyProfilePage } = await import("@/components/profile/my-profile-page");
+  render(<MyProfilePage />);
+  const goingTab = await screen.findByRole("button", { name: /going events/i });
+  await userEvent.click(goingTab);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  cleanup();
+  fetchMyGoingEventsMock.mockReset();
+  vi.resetModules();
+});
+
+describe("Going Events tab — navigation", () => {
+  beforeEach(() => {
+    fetchMyGoingEventsMock.mockResolvedValue([]);
+  });
+
+  it("renders the Going Events nav button", async () => {
+    const { MyProfilePage } = await import("@/components/profile/my-profile-page");
+    render(<MyProfilePage />);
+    expect(await screen.findByRole("button", { name: /going events/i })).toBeInTheDocument();
+  });
+
+  it("shows the Going Events section when the tab is clicked", async () => {
+    await renderProfileAndOpenGoingTab();
+    expect(await screen.findByText(/going & attended/i)).toBeInTheDocument();
+  });
+});
+
+describe("Going Events tab — upcoming sub-tab", () => {
+  it("renders a card for each upcoming going event", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([
+      makeEvent({ id: "ev-1", title: "Morning Run" }),
+      makeEvent({ id: "ev-2", title: "Evening Yoga" }),
+    ]);
+    await renderProfileAndOpenGoingTab();
+
+    expect(await screen.findByText("Morning Run")).toBeInTheDocument();
+    expect(screen.getByText("Evening Yoga")).toBeInTheDocument();
+  });
+
+  it("shows 'Going' badge on upcoming events", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([makeEvent()]);
+    await renderProfileAndOpenGoingTab();
+
+    const badges = await screen.findAllByText(/going/i);
+    // At least one badge with "Going" text (the card badge)
+    expect(badges.length).toBeGreaterThan(0);
+  });
+
+  it("shows the empty state when there are no upcoming going events", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([]);
+    await renderProfileAndOpenGoingTab();
+
+    expect(await screen.findByText(/no upcoming events/i)).toBeInTheDocument();
+  });
+
+  it("links each card to the event detail page", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([makeEvent({ id: "ev-abc" })]);
+    await renderProfileAndOpenGoingTab();
+
+    const link = await screen.findByRole("link", { name: /sunset yoga/i });
+    expect(link).toHaveAttribute("href", "/event/ev-abc");
+  });
+
+  it("renders the event category badge", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([
+      makeEvent({
+        categories: [{ id: "c-1", name: "Wellness", is_predefined: true, is_approved: true }],
+      }),
+    ]);
+    await renderProfileAndOpenGoingTab();
+    expect(await screen.findByText("Wellness")).toBeInTheDocument();
+  });
+});
+
+describe("Going Events tab — past sub-tab", () => {
+  it("shows 'Attended' badge and event on the past tab", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([
+      makeEvent({
+        id: "ev-past",
+        title: "Beach Volleyball",
+        start_datetime: "2024-06-01T10:00:00Z",
+        end_datetime: "2024-06-01T12:00:00Z",
+        status: "ended",
+      }),
+    ]);
+    await renderProfileAndOpenGoingTab();
+
+    // Switch to the Past tab
+    const pastTab = await screen.findByRole("button", { name: /past/i });
+    await userEvent.click(pastTab);
+
+    expect(await screen.findByText("Beach Volleyball")).toBeInTheDocument();
+    expect(screen.getByText(/attended/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no attended events", async () => {
+    fetchMyGoingEventsMock.mockResolvedValue([]);
+    await renderProfileAndOpenGoingTab();
+
+    const pastTab = await screen.findByRole("button", { name: /past/i });
+    await userEvent.click(pastTab);
+
+    expect(await screen.findByText(/no attended events yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("Going Events tab — error state", () => {
+  it("shows an error message when the fetch fails", async () => {
+    fetchMyGoingEventsMock.mockRejectedValue(new Error("Network error"));
+    await renderProfileAndOpenGoingTab();
+
+    expect(
+      await screen.findByText(/we could not load your going events/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/going-events-profile.test.tsx
+++ b/frontend/tests/going-events-profile.test.tsx
@@ -22,6 +22,7 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock }),
   useParams: () => ({}),
   usePathname: () => "/profile",
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 // Auth — authenticated user
@@ -224,8 +225,6 @@ describe("Going Events tab — error state", () => {
     fetchMyGoingEventsMock.mockRejectedValue(new Error("Network error"));
     await renderProfileAndOpenGoingTab();
 
-    expect(
-      await screen.findByText(/we could not load your going events/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/we could not load your going events/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Closes #317

Adds a **Going Events** tab to the user's profile page so they can see all events they've marked as going, split into upcoming and past (attended) sub-tabs.

### Changes

**`frontend/src/lib/events-api.ts`**
- Added `fetchMyGoingEvents()` — calls `GET /attendances/me/events` with the user's auth token and returns `EventListItem[]`

**`frontend/src/components/profile/my-profile-page.tsx`**
- Added a **Going Events** nav tab alongside Bookmarks / Hosted Events
- Added `GoingEventCard` component — displays event image, title, date, location, category badge, and a **Going** or **Attended** status badge depending on whether the event is upcoming or past
- Added **Upcoming** / **Past** sub-tabs to filter the list
- Loading skeleton, empty states ("No upcoming events" / "No attended events yet"), and an error state when the fetch fails

**`frontend/tests/going-events-api.test.ts`** *(new)*
- Unit tests for `fetchMyGoingEvents`: correct endpoint, auth header, parsed response, empty array case

**`frontend/tests/going-events-profile.test.tsx`** *(new)*
- Component tests for the Going Events tab: tab renders, section opens on click, event cards with correct hrefs, Going/Attended badges, empty states, Past sub-tab switching, error state

### Test plan
- [ ] Navigate to `/profile` — "Going Events" tab appears in the sidebar nav
- [ ] Click "Going Events" — section opens with Upcoming sub-tab active
- [ ] Events the user has RSVPed to with a future date appear as cards with a **Going** badge
- [ ] Click "Past" — events that have ended appear with an **Attended** badge
- [ ] Empty states show when there are no upcoming / attended events
- [ ] Clicking an event card navigates to `/event/<id>`
- [ ] `npm test` passes for the two new test files