### PR TITLE
fix(mobile): cancel previous loadJob on every loadEvents call (#256)

### DIFF
--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
@@ -20,6 +20,7 @@ class DiscoveryViewModel(
     private var token: String? = null
     private var tokenInitialized = false
     private var searchJob: Job? = null
+    private var loadJob: Job? = null
 
     init {
         loadCategories()
@@ -212,7 +213,8 @@ class DiscoveryViewModel(
         else
             state.copy(isLoadingMore = true)
 
-        viewModelScope.launch {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
             repository.getEvents(
                 token = token,
                 search = state.search.takeIf { it.isNotBlank() },

--- a/mobile/app/src/test/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModelTest.kt
+++ b/mobile/app/src/test/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModelTest.kt
@@ -226,6 +226,39 @@ class DiscoveryViewModelTest {
     }
 
     @Test
+    fun `rapid applyFilters cancels previous loadJob so stale response cannot overwrite newer results`() = runTest {
+        // First call returns event A; second call returns event B.
+        val eventA = sampleEvent("a", false)
+        val eventB = sampleEvent("b", false)
+        var callCount = 0
+        coEvery {
+            repository.getEvents(
+                token = any(), search = any(), categoryId = any(), quickFilter = any(),
+                wheelchair = any(), accessibleRestroom = any(), elevator = any(),
+                seating = any(), captions = any(), quietFriendly = any(),
+                sort = any(), nearLat = any(), nearLng = any(), radiusKm = any(),
+                page = any(), pageSize = any()
+            )
+        } answers {
+            callCount++
+            if (callCount == 1) Result.success(emptyResponse().copy(items = listOf(eventA)))
+            else Result.success(emptyResponse().copy(items = listOf(eventB)))
+        }
+
+        val vm = viewModel()
+        // First applyFilters — launches loadJob (R1).
+        vm.applyFilters()
+        // Second applyFilters immediately — cancels R1, launches R2.
+        vm.applyFilters()
+        advanceUntilIdle()
+
+        // Only R2's result (eventB) should be in state; R1 was cancelled before it could write.
+        val ids = vm.uiState.value.events.map { it.id }
+        assertFalse(ids.contains("a"), "Stale R1 result must not appear after R2 wins")
+        assertTrue(ids.contains("b"), "R2 result must be rendered")
+    }
+
+    @Test
     fun `activeFilterCount counts active flags`() {
         val vm = viewModel()
         assertEquals(0, vm.activeFilterCount())


### PR DESCRIPTION
## Summary

Closes #256.

Extends the existing cancel-before-launch pattern from `onSearchChange` to every `loadEvents` invocation, closing a race condition where a stale API response could overwrite newer results.

## Problem

`onSearchChange` already used a dedicated `searchJob` that was cancelled on each new keystroke, preventing stale search responses. However, every other trigger that calls `loadEvents` — `applyFilters`, `setToken`, `refresh`, `enableProximitySort` — launched an independent coroutine with no cancellation of the previous one.

Race scenario:
1. User applies filter A → request R1 starts.
2. User immediately applies filter B → request R2 starts.
3. R2 finishes first (e.g. cached or faster network path) — correct results are rendered.
4. R1 finishes later → its `onSuccess` block runs and **overwrites R2's results with stale data**.

## Fix

Added a single `loadJob: Job?` field. At the top of `loadEvents`, `loadJob?.cancel()` is called before the new coroutine is launched and assigned to `loadJob`. This is a one-line structural change — no logic is altered.

```kotlin
// Before
viewModelScope.launch {
    repository.getEvents(...)
}

// After
loadJob?.cancel()
loadJob = viewModelScope.launch {
    repository.getEvents(...)
}
