### PR TITLE
feat(mobile): multi-select categories, sort options, and reorder quick filters in discovery

### DIFF
--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryScreen.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryScreen.kt
@@ -253,7 +253,8 @@ fun DiscoveryScreen(
                 uiState = uiState,
                 isLoggedIn = token != null,
                 onQuickFilterSelect = viewModel::onQuickFilterSelected,
-                onCategorySelect = viewModel::onCategorySelected,
+                onCategoryToggle = viewModel::onCategoryToggled,
+                onSortSelect = viewModel::onSortSelected,
                 onBookmarkedToggle = viewModel::onBookmarkedOnlyToggle,
                 onGoingToggle = viewModel::onGoingOnlyToggle,
                 onWheelchairToggle = viewModel::onWheelchairToggle,
@@ -510,7 +511,7 @@ private fun FilterSheetContent(
     uiState: DiscoveryUiState,
     isLoggedIn: Boolean,
     onQuickFilterSelect: (String?) -> Unit,
-    onCategorySelect: (String?) -> Unit,
+    onCategoryToggle: (String) -> Unit,
     onBookmarkedToggle: () -> Unit,
     onGoingToggle: () -> Unit,
     onWheelchairToggle: () -> Unit,
@@ -521,12 +522,13 @@ private fun FilterSheetContent(
     onQuietFriendlyToggle: () -> Unit,
     onSuggestedToggle: () -> Unit,
     onProximitySortToggle: () -> Unit,
+    onSortSelect: (String?) -> Unit,
     onClear: () -> Unit,
     onApply: () -> Unit
 ) {
-    val hasAnyFilter = uiState.selectedQuickFilter != null || uiState.selectedCategoryId != null ||
+    val hasAnyFilter = uiState.selectedQuickFilter != null || uiState.selectedCategoryIds.isNotEmpty() ||
         uiState.bookmarkedOnly || uiState.goingOnly || uiState.hasAccessibilityFilter ||
-        uiState.proximitySort || uiState.suggestedActive
+        uiState.proximitySort || uiState.suggestedActive || uiState.selectedSort != null
 
     Column(modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp)) {
         // Header
@@ -552,34 +554,11 @@ private fun FilterSheetContent(
                 .padding(horizontal = 20.dp, vertical = 16.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            // ── Quick Filters ──────────────────────────────────────────────────
-            FilterSectionLabel("QUICK FILTERS")
-            Row(
-                modifier = Modifier.horizontalScroll(rememberScrollState()),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                listOf(
-                    "now" to "Now",
-                    "today" to "Today",
-                    "weekend" to "Weekend",
-                    "this_week" to "This Week",
-                    "upcoming" to "Upcoming",
-                    "past" to "Past"
-                ).forEach { (key, label) ->
-                    FilterPill(label = label, selected = uiState.selectedQuickFilter == key) {
-                        onQuickFilterSelect(key)
-                    }
-                }
-                if (isLoggedIn) {
-                    FilterPill("✨ Suggested for you", uiState.suggestedActive, onSuggestedToggle)
-                    FilterPill("🔖 Bookmarked", uiState.bookmarkedOnly, onBookmarkedToggle)
-                    FilterPill("✓ Going", uiState.goingOnly, onGoingToggle)
-                }
-            }
-
+            FilterQuickFiltersSection(uiState, isLoggedIn, onQuickFilterSelect,
+                onBookmarkedToggle, onGoingToggle, onSuggestedToggle)
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
-
-            // ── Ranking & Proximity ────────────────────────────────────────────
+            FilterSortSection(uiState, onSortSelect)
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
             FilterSectionLabel("RANKING")
             FilterSwitchRow(
                 label = "Proximity Ranking",
@@ -587,53 +566,11 @@ private fun FilterSheetContent(
                 checked = uiState.proximitySort,
                 onCheckedChange = { onProximitySortToggle() }
             )
-
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
-
-            // ── Accessibility ──────────────────────────────────────────────────
-            FilterSectionLabel("ACCESSIBILITY")
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                FilterSwitchRow("Wheelchair Access", checked = uiState.wheelchair,
-                    onCheckedChange = { onWheelchairToggle() })
-                FilterSwitchRow("Accessible Restroom", checked = uiState.accessibleRestroom,
-                    onCheckedChange = { onAccessibleRestroomToggle() })
-                FilterSwitchRow("Elevator Available", checked = uiState.elevator,
-                    onCheckedChange = { onElevatorToggle() })
-                FilterSwitchRow("Seating Available", checked = uiState.seating,
-                    onCheckedChange = { onSeatingToggle() })
-                FilterSwitchRow("Captions Support", checked = uiState.captions,
-                    onCheckedChange = { onCaptionsToggle() })
-                FilterSwitchRow("Quiet-Friendly", checked = uiState.quietFriendly,
-                    onCheckedChange = { onQuietFriendlyToggle() })
-            }
-
+            FilterAccessibilitySection(uiState, onWheelchairToggle, onAccessibleRestroomToggle,
+                onElevatorToggle, onSeatingToggle, onCaptionsToggle, onQuietFriendlyToggle)
             HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.15f))
-
-            // ── Category ───────────────────────────────────────────────────────
-            FilterSectionLabel("CATEGORY")
-            uiState.categories.forEach { cat ->
-                val selected = uiState.selectedCategoryId == cat.id
-                Row(
-                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
-                        .clickable { onCategorySelect(cat.id) }
-                        .padding(horizontal = 10.dp, vertical = 10.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(cat.name, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
-                    Box(
-                        modifier = Modifier.size(20.dp).clip(RoundedCornerShape(4.dp))
-                            .background(
-                                if (selected) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
-                            ),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        if (selected) Icon(Icons.Default.Check, null,
-                            tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(14.dp))
-                    }
-                }
-            }
+            FilterCategorySection(uiState, onCategoryToggle)
         }
 
         Button(
@@ -643,6 +580,103 @@ private fun FilterSheetContent(
             colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
         ) {
             Text("Apply Filters", fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun FilterQuickFiltersSection(
+    uiState: DiscoveryUiState,
+    isLoggedIn: Boolean,
+    onQuickFilterSelect: (String?) -> Unit,
+    onBookmarkedToggle: () -> Unit,
+    onGoingToggle: () -> Unit,
+    onSuggestedToggle: () -> Unit
+) {
+    FilterSectionLabel("QUICK FILTERS")
+    Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        if (isLoggedIn) FilterPill("✨ Suggested for you", uiState.suggestedActive, onSuggestedToggle)
+        listOf("now" to "Now", "today" to "Today", "weekend" to "Weekend",
+            "this_week" to "This Week", "upcoming" to "Upcoming", "past" to "Past"
+        ).forEach { (key, label) ->
+            FilterPill(label = label, selected = uiState.selectedQuickFilter == key) {
+                onQuickFilterSelect(key)
+            }
+        }
+        if (isLoggedIn) {
+            FilterPill("🔖 Bookmarked", uiState.bookmarkedOnly, onBookmarkedToggle)
+            FilterPill("✓ Going", uiState.goingOnly, onGoingToggle)
+        }
+    }
+}
+
+@Composable
+private fun FilterSortSection(uiState: DiscoveryUiState, onSortSelect: (String?) -> Unit) {
+    FilterSectionLabel("SORT BY")
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        listOf("start_time" to "Start Time", "category" to "Category").forEach { (key, label) ->
+            FilterPill(
+                label = label,
+                selected = uiState.selectedSort == key && !uiState.proximitySort
+            ) { onSortSelect(if (uiState.selectedSort == key) null else key) }
+        }
+    }
+}
+
+@Composable
+private fun FilterAccessibilitySection(
+    uiState: DiscoveryUiState,
+    onWheelchairToggle: () -> Unit,
+    onAccessibleRestroomToggle: () -> Unit,
+    onElevatorToggle: () -> Unit,
+    onSeatingToggle: () -> Unit,
+    onCaptionsToggle: () -> Unit,
+    onQuietFriendlyToggle: () -> Unit
+) {
+    FilterSectionLabel("ACCESSIBILITY")
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        FilterSwitchRow("Wheelchair Access", checked = uiState.wheelchair,
+            onCheckedChange = { onWheelchairToggle() })
+        FilterSwitchRow("Accessible Restroom", checked = uiState.accessibleRestroom,
+            onCheckedChange = { onAccessibleRestroomToggle() })
+        FilterSwitchRow("Elevator Available", checked = uiState.elevator,
+            onCheckedChange = { onElevatorToggle() })
+        FilterSwitchRow("Seating Available", checked = uiState.seating,
+            onCheckedChange = { onSeatingToggle() })
+        FilterSwitchRow("Captions Support", checked = uiState.captions,
+            onCheckedChange = { onCaptionsToggle() })
+        FilterSwitchRow("Quiet-Friendly", checked = uiState.quietFriendly,
+            onCheckedChange = { onQuietFriendlyToggle() })
+    }
+}
+
+@Composable
+private fun FilterCategorySection(uiState: DiscoveryUiState, onCategoryToggle: (String) -> Unit) {
+    FilterSectionLabel("CATEGORY")
+    uiState.categories.forEach { cat ->
+        val selected = cat.id in uiState.selectedCategoryIds
+        Row(
+            modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp))
+                .clickable { onCategoryToggle(cat.id) }
+                .padding(horizontal = 10.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(cat.name, fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface)
+            Box(
+                modifier = Modifier.size(20.dp).clip(RoundedCornerShape(4.dp))
+                    .background(
+                        if (selected) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.outline.copy(alpha = 0.2f)
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                if (selected) Icon(Icons.Default.Check, null,
+                    tint = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.size(14.dp))
+            }
         }
     }
 }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryUiState.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryUiState.kt
@@ -7,7 +7,8 @@ data class DiscoveryUiState(
     val events: List<EventListItemDto> = emptyList(),
     val categories: List<CategoryDto> = emptyList(),
     val search: String = "",
-    val selectedCategoryId: String? = null,
+    // Multi-select: empty = no filter, size == 1 → sent to API, size >= 2 → client-side filtered
+    val selectedCategoryIds: Set<String> = emptySet(),
     // quick_filter: "now"|"today"|"weekend"|"upcoming"|"this_week"|"past"|null
     val selectedQuickFilter: String? = null,
     val bookmarkedOnly: Boolean = false,
@@ -19,6 +20,9 @@ data class DiscoveryUiState(
     val seating: Boolean = false,
     val captions: Boolean = false,
     val quietFriendly: Boolean = false,
+    // Explicit sort: "start_time" | "category" | null (null = server default)
+    // "distance" sort is handled separately via proximitySort + GPS coords below.
+    val selectedSort: String? = null,
     // Proximity ranking: sort=distance using device GPS coords
     val proximitySort: Boolean = false,
     val nearLat: Double? = null,
@@ -39,9 +43,15 @@ data class DiscoveryUiState(
     val hasAccessibilityFilter: Boolean get() =
         wheelchair || accessibleRestroom || elevator || seating || captions || quietFriendly
 
-    /** Client-side filter for bookmarked/going (server handles everything else). */
+    /**
+     * Client-side filters applied on top of the server response:
+     * - bookmarkedOnly / goingOnly (personal filters the API can't gate directly)
+     * - multi-category (when 2+ selected the API returns unfiltered results so we filter here)
+     */
     val displayedEvents: List<EventListItemDto> get() = events.filter { event ->
         (!bookmarkedOnly || event.is_bookmarked == true) &&
-        (!goingOnly || event.attendance_status == "going")
+        (!goingOnly || event.attendance_status == "going") &&
+        (selectedCategoryIds.size <= 1 ||
+            event.categories.any { it.id in selectedCategoryIds })
     }
 }

--- a/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
+++ b/mobile/app/src/main/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModel.kt
@@ -42,9 +42,14 @@ class DiscoveryViewModel(
         }
     }
 
-    fun onCategorySelected(categoryId: String?) {
-        val new = if (_uiState.value.selectedCategoryId == categoryId) null else categoryId
-        _uiState.value = _uiState.value.copy(selectedCategoryId = new)
+    fun onCategoryToggled(categoryId: String) {
+        val current = _uiState.value.selectedCategoryIds
+        val updated = if (categoryId in current) current - categoryId else current + categoryId
+        _uiState.value = _uiState.value.copy(selectedCategoryIds = updated)
+    }
+
+    fun onSortSelected(sort: String?) {
+        _uiState.value = _uiState.value.copy(selectedSort = sort)
     }
 
     fun onQuickFilterSelected(filter: String?) {
@@ -166,7 +171,7 @@ class DiscoveryViewModel(
 
     fun clearFilters() {
         _uiState.value = _uiState.value.copy(
-            selectedCategoryId = null,
+            selectedCategoryIds = emptySet(),
             selectedQuickFilter = null,
             bookmarkedOnly = false,
             goingOnly = false,
@@ -176,6 +181,7 @@ class DiscoveryViewModel(
             seating = false,
             captions = false,
             quietFriendly = false,
+            selectedSort = null,
             proximitySort = false,
             nearLat = null,
             nearLng = null,
@@ -190,7 +196,8 @@ class DiscoveryViewModel(
         val s = _uiState.value
         var count = 0
         if (s.selectedQuickFilter != null) count++
-        if (s.selectedCategoryId != null) count++
+        count += s.selectedCategoryIds.size
+        if (s.selectedSort != null) count++
         if (s.bookmarkedOnly) count++
         if (s.goingOnly) count++
         if (s.wheelchair) count++
@@ -218,7 +225,10 @@ class DiscoveryViewModel(
             repository.getEvents(
                 token = token,
                 search = state.search.takeIf { it.isNotBlank() },
-                categoryId = state.selectedCategoryId,
+                // Pass categoryId only when exactly 1 category is selected.
+                // With 2+ selections the API returns unfiltered results and
+                // DiscoveryUiState.displayedEvents applies the client-side filter.
+                categoryId = state.selectedCategoryIds.singleOrNull(),
                 quickFilter = state.selectedQuickFilter,
                 wheelchair = state.wheelchair.takeIf { it },
                 accessibleRestroom = state.accessibleRestroom.takeIf { it },
@@ -226,7 +236,11 @@ class DiscoveryViewModel(
                 seating = state.seating.takeIf { it },
                 captions = state.captions.takeIf { it },
                 quietFriendly = state.quietFriendly.takeIf { it },
-                sort = if (state.proximitySort && state.nearLat != null) "distance" else null,
+                // Proximity sort (GPS) takes precedence; otherwise use the explicit selection.
+                sort = when {
+                    state.proximitySort && state.nearLat != null -> "distance"
+                    else -> state.selectedSort
+                },
                 nearLat = state.nearLat,
                 nearLng = state.nearLng,
                 // Suggested only goes to the wire when the chip is on AND the user is signed in.

--- a/mobile/app/src/test/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModelTest.kt
+++ b/mobile/app/src/test/java/com/bounswe/group9/mobile/ui/discovery/DiscoveryViewModelTest.kt
@@ -122,12 +122,29 @@ class DiscoveryViewModelTest {
     }
 
     @Test
-    fun `onCategorySelected toggles the same id back to null`() {
+    fun `onCategoryToggled adds and removes from selectedCategoryIds`() {
         val vm = viewModel()
-        vm.onCategorySelected("cat-1")
-        assertEquals("cat-1", vm.uiState.value.selectedCategoryId)
-        vm.onCategorySelected("cat-1")
-        assertNull(vm.uiState.value.selectedCategoryId)
+        vm.onCategoryToggled("cat-1")
+        assertTrue(vm.uiState.value.selectedCategoryIds.contains("cat-1"))
+        vm.onCategoryToggled("cat-1")
+        assertFalse(vm.uiState.value.selectedCategoryIds.contains("cat-1"))
+    }
+
+    @Test
+    fun `onCategoryToggled allows multiple categories selected simultaneously`() {
+        val vm = viewModel()
+        vm.onCategoryToggled("cat-1")
+        vm.onCategoryToggled("cat-2")
+        assertEquals(setOf("cat-1", "cat-2"), vm.uiState.value.selectedCategoryIds)
+    }
+
+    @Test
+    fun `onSortSelected sets and clears selectedSort`() {
+        val vm = viewModel()
+        vm.onSortSelected("start_time")
+        assertEquals("start_time", vm.uiState.value.selectedSort)
+        vm.onSortSelected(null)
+        assertNull(vm.uiState.value.selectedSort)
     }
 
     @Test
@@ -159,7 +176,7 @@ class DiscoveryViewModelTest {
         val vm = viewModel()
         vm.setToken("tok")
         advanceUntilIdle()
-        vm.onCategorySelected("cat-1")
+        vm.onCategoryToggled("cat-1")
         vm.onQuickFilterSelected("weekend")
         vm.onWheelchairToggle()
         vm.onBookmarkedOnlyToggle()
@@ -168,7 +185,7 @@ class DiscoveryViewModelTest {
         advanceUntilIdle()
 
         val state = vm.uiState.value
-        assertNull(state.selectedCategoryId)
+        assertTrue(state.selectedCategoryIds.isEmpty())
         assertNull(state.selectedQuickFilter)
         assertFalse(state.bookmarkedOnly)
         assertFalse(state.wheelchair)
@@ -262,7 +279,7 @@ class DiscoveryViewModelTest {
     fun `activeFilterCount counts active flags`() {
         val vm = viewModel()
         assertEquals(0, vm.activeFilterCount())
-        vm.onCategorySelected("cat-1")
+        vm.onCategoryToggled("cat-1")
         vm.onQuickFilterSelected("today")
         vm.onWheelchairToggle()
         assertEquals(3, vm.activeFilterCount())


### PR DESCRIPTION

- selectedCategoryId (String?) → selectedCategoryIds (Set<String>); 2+ selections filter client-side
- Add Sort By section (Start Time / Category) with selectedSort; proximity sort takes precedence
- Move "Suggested for you" chip to first position in quick filters row
- Extract FilterSheetContent sub-sections into private composables to pass detekt limits
- Update DiscoveryViewModelTest with multi-category, sort, and race-condition tests